### PR TITLE
Core/Spells: Weapon damage and Mod Damage Taken auras

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8122,8 +8122,10 @@ uint32 Unit::MeleeDamageBonusTaken(Unit* attacker, uint32 pdamage, WeaponAttackT
 
     int32 TakenFlatBenefit = 0;
 
+    uint32 meleeDamageSchoolMask = spellProto ? spellProto->SchoolMask : attacker->GetMeleeDamageSchoolMask();
+
     // ..taken
-    TakenFlatBenefit += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_TAKEN, attacker->GetMeleeDamageSchoolMask());
+    TakenFlatBenefit += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_TAKEN, meleeDamageSchoolMask);
 
     if (attType != RANGED_ATTACK)
         TakenFlatBenefit += GetTotalAuraModifier(SPELL_AURA_MOD_MELEE_DAMAGE_TAKEN);
@@ -8137,7 +8139,7 @@ uint32 Unit::MeleeDamageBonusTaken(Unit* attacker, uint32 pdamage, WeaponAttackT
     float TakenTotalMod = 1.0f;
 
     // ..taken
-    TakenTotalMod *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, attacker->GetMeleeDamageSchoolMask());
+    TakenTotalMod *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, meleeDamageSchoolMask);
 
     // .. taken pct (special attacks)
     if (spellProto)


### PR DESCRIPTION
### Description
Looks like weapon damage is treated by core as physical when damage calculations are done, even if damage actually is not physical
That means arcane weapon damage will be not increased if target is affected by an aura which increases arcane damage, but it will work if aura increases physical damage

### Expected behaviour
Weapon damage should be not treated only as physical when damage calculations are done

### Steps to reproduce the problem
Apply Aura: Mod Damage Taken - Flat (Arcane)
Value: 1200
https://tcubuntu.northeurope.cloudapp.azure.com/aowow/?spell=34794

An instant weapon attack that causes 50% of weapon damage
School Arcane
https://tcubuntu.northeurope.cloudapp.azure.com/aowow/?spell=34799

.npc add temp 17976
aggro her
.cast 34794
.cast 34799
damage: ~200

Apply Aura: Mod Damage Taken - Flat (Physical)
Value: 1000
https://tcubuntu.northeurope.cloudapp.azure.com/aowow/?spell=59009

.npc add temp 17976
aggro her
.cast 59009
.cast 34799
damage: ~1200