### PR TITLE
Fix Horde Gnomeregan Teleport

### DIFF
--- a/sql/updates/world/3.3.5/2022_06_15_01_world.sql
+++ b/sql/updates/world/3.3.5/2022_06_15_01_world.sql
@@ -1,0 +1,9 @@
+DELETE FROM `areatrigger_scripts` WHERE `entry` IN (1103,1104);
+INSERT INTO `areatrigger_scripts` (`entry`,`ScriptName`) VALUES
+(1103,'at_booty_bay_to_gnomeregan'),
+(1104,'at_booty_bay_to_gnomeregan');
+
+DELETE FROM `areatrigger_teleport` WHERE `ID` IN (1103,1104);
+INSERT INTO `areatrigger_teleport` (`ID`,`Name`,`target_map`,`target_position_x`,`target_position_y`,`target_position_z`,`target_orientation`,`VerifiedBuild`) VALUES
+(1103,'Booty Bay to Gnomeregan',0,-5100.92,754.567,260.55,5.49,0),
+(1104,'Gnomeregan to Booty Bay',0,-14461.9,458.295,15.1639,3.48,0);

--- a/src/server/scripts/EasternKingdoms/eastern_kingdoms_script_loader.cpp
+++ b/src/server/scripts/EasternKingdoms/eastern_kingdoms_script_loader.cpp
@@ -177,6 +177,7 @@ void AddSC_instance_zulgurub();
 //void AddSC_arathi_highlands();
 void AddSC_blasted_lands();
 void AddSC_duskwood();
+void AddSC_stranglethorn();
 //void AddSC_eastern_plaguelands();
 void AddSC_elwynn_forest();
 //void AddSC_ghostlands();
@@ -355,6 +356,7 @@ void AddEasternKingdomsScripts()
     //AddSC_arathi_highlands();
     AddSC_blasted_lands();
     AddSC_duskwood();
+    AddSC_stranglethorn();
     //AddSC_eastern_plaguelands();
     AddSC_elwynn_forest();
     //AddSC_ghostlands();

--- a/src/server/scripts/EasternKingdoms/zone_stranglethorn.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_stranglethorn.cpp
@@ -1,0 +1,30 @@
+#include "ScriptMgr.h"
+#include "Player.h"
+
+class at_booty_bay_to_gnomeregan : public AreaTriggerScript
+{
+    public:
+        at_booty_bay_to_gnomeregan() : AreaTriggerScript("at_booty_bay_to_gnomeregan") { }
+
+        bool OnTrigger(Player* player, AreaTriggerEntry const* /*trigger*/) override
+        {
+            if (! player)
+                return true;
+
+            /** Alliance Can't Use. */
+            if (player->GetTeam() != HORDE && !player->IsGameMaster())
+                return true;
+
+            /** Has Item. */
+            if (! player->HasItemCount(9173, 1, false))
+                return true;
+
+            /** Success, allow teleport. */
+            return false;
+        };
+};
+
+void AddSC_stranglethorn()
+{
+    new at_booty_bay_to_gnomeregan();
+}


### PR DESCRIPTION
Allows access to Gnomeregan for Horde so long as they have a Goblin Transponder. 

https://classic.wowhead.com/item=9173/goblin-transponder
