### PR TITLE
Mob Health Speed

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2153,10 +2153,12 @@ void Creature::setDeathState(DeathState s)
 
         setActive(false);
 
+        /** @epoch-start */
         if (HasSearchedAssistance())
         {
             SetNoSearchAssistance(false);
         }
+        /** @epoch-end */
 
         //Dismiss group if is leader
         if (m_formation && m_formation->GetLeader() == this)

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2153,7 +2153,10 @@ void Creature::setDeathState(DeathState s)
 
         setActive(false);
 
-        SetNoSearchAssistance(false);
+        if (HasSearchedAssistance())
+        {
+            SetNoSearchAssistance(false);
+        }
 
         //Dismiss group if is leader
         if (m_formation && m_formation->GetLeader() == this)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8738,7 +8738,9 @@ void Unit::UpdateSpeed(UnitMoveType mtype)
             break;
     }
 
+    /** @epoch-start */
     int32 healthSlow = 0;
+    /** @epoch-end */
     if (Creature* creature = ToCreature())
     {
         if (creature->HasUnitTypeMask(UNIT_MASK_MINION) && !creature->IsInCombat())
@@ -8756,16 +8758,20 @@ void Unit::UpdateSpeed(UnitMoveType mtype)
             }
         }
 
+        /** @epoch-start */
         uint32 immuneMask = creature->GetCreatureTemplate()->MechanicImmuneMask;
         if (!IsPet() && !(IsControlledByPlayer() && IsVehicle()) && !(immuneMask & (1 << (MECHANIC_SNARE - 1))) && !(creature->IsDungeonBoss())) {
             healthSlow = (int32) std::min(0.0f, (1.66f * (GetHealthPct() - 30.0f)));
         }
+        /** @epoch-end */
     }
 
+    /** @epoch-start */
     if (healthSlow)
     {
         AddPct(speed, healthSlow);
     }
+    /** @epoch-end */
 
     // Apply strongest slow aura mod to speed
     int32 slow = GetMaxNegativeAuraModifier(SPELL_AURA_MOD_DECREASE_SPEED);
@@ -9490,14 +9496,18 @@ void Unit::SetHealth(uint32 val)
             val = maxHealth;
     }
 
+    /** @epoch-start */
     float prevHealthPct = GetHealthPct();
+    /** @epoch-end */
 
     SetUInt32Value(UNIT_FIELD_HEALTH, val);
 
+    /** @epoch-start */
     if (GetTypeId() == TYPEID_UNIT && (prevHealthPct < 30.0 || HealthBelowPct(30)))
     {
         UpdateSpeed(MOVE_RUN);
     }
+    /** @epoch-end */
 
     // group update
     if (Player* player = ToPlayer())

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8756,8 +8756,9 @@ void Unit::UpdateSpeed(UnitMoveType mtype)
             }
         }
 
-        if (!IsPet() && !(IsControlledByPlayer() && IsVehicle()) && !(creature->HasMechanicTemplateImmunity(MECHANIC_SNARE)) && !(creature->IsDungeonBoss())) {
-            slowFromHealth = (int32) std::min(0.0f, (1.66f * (GetHealthPct() - 30.0f)));
+        uint32 immuneMask = creature->GetCreatureTemplate()->MechanicImmuneMask;
+        if (!IsPet() && !(IsControlledByPlayer() && IsVehicle()) && !(immuneMask & (1 << (MECHANIC_SNARE - 1))) && !(creature->IsDungeonBoss())) {
+            healthSlow = (int32) std::min(0.0f, (1.66f * (GetHealthPct() - 30.0f)));
         }
     }
 
@@ -9495,7 +9496,7 @@ void Unit::SetHealth(uint32 val)
 
     if (GetTypeId() == TYPEID_UNIT && (prevHealthPct < 30.0 || HealthBelowPct(30)))
     {
-        UpdateSpeed(MOVE_RUN, false);
+        UpdateSpeed(MOVE_RUN);
     }
 
     // group update

--- a/src/server/game/Movement/Spline/MoveSplineInit.cpp
+++ b/src/server/game/Movement/Spline/MoveSplineInit.cpp
@@ -114,9 +114,6 @@ namespace Movement
                 moveFlagsForSpeed &= ~MOVEMENTFLAG_WALKING;
 
             args.velocity = unit->GetSpeed(SelectSpeedType(moveFlagsForSpeed));
-            if (Creature* creature = unit->ToCreature())
-                if (creature->HasSearchedAssistance())
-                    args.velocity *= 0.66f;
         }
 
         // limit the speed in the same way the client does

--- a/src/server/game/Movement/Spline/MoveSplineInit.cpp
+++ b/src/server/game/Movement/Spline/MoveSplineInit.cpp
@@ -114,6 +114,11 @@ namespace Movement
                 moveFlagsForSpeed &= ~MOVEMENTFLAG_WALKING;
 
             args.velocity = unit->GetSpeed(SelectSpeedType(moveFlagsForSpeed));
+            /** @epoch-start */
+            // if (Creature* creature = unit->ToCreature())
+            //     if (creature->HasSearchedAssistance())
+            //         args.velocity *= 0.66f;
+            /** @epoch-end */
         }
 
         // limit the speed in the same way the client does


### PR DESCRIPTION
**Changes proposed**:

- Implements the logic of creatures having 1.666% reduced speed per 1% health below 30% health.

**Tests performed**: Tested via questing and a dungeon run.
