### PR TITLE
Epoch Resistance Changes

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1840,7 +1840,22 @@ void Unit::HandleEmoteCommand(Emote emoteId)
     else
         resistanceConstant = level * 5.0f;
 
-    return victimResistance / (victimResistance + resistanceConstant);
+    // @epoch-start
+    //return victimResistance / (victimResistance + resistanceConstant);
+    
+    // If resistance is lower than 20% of cap, formula (tweaked from 1.12 base) is slightly different to make the first few points more impactful
+    if (victimResistance < (resistanceConstant * 0.2))
+        return 0.75 * (victimResistance / resistanceConstant) + (resistanceConstant * 0.2 - victimResistance) * 0.0002;
+    // Else, if resistance is below 2/3rds of cap, use the 1.12 formula
+    else if (victimResistance < (resistanceConstant * 0.6666))
+        return 0.75 * (victimResistance / resistanceConstant);
+    // Else, if above the resistance cap, always return the value of the cap
+    else if (victimResistance > resistanceConstant)
+        return 0.75 * (resistanceConstant / resistanceConstant);
+    // Finally, else, use the above 2/3rds of cap 1.12 formula
+    else
+        return 0.5625 * (victimResistance / resistanceConstant) + 0.125;
+    // @epoch-end
 }
 
 /*static*/ void Unit::CalcAbsorbResist(DamageInfo& damageInfo, Spell* spell /*= nullptr*/)


### PR DESCRIPTION
Partial resistances have been changed to be a hybrid between Classic and Wrath of the Lich King. Resistances now work as such:

Resistances cap at the original Classic cap of Caster Level * 5, this means the resistance cap at level 60 vs a skull level boss is 315. Every point beyond 315 is the same as being at 315.

The resistance points up to the amount equal to 20% of your cap are now slightly more effective. At level 60 vs a skull level boss this is up to 63 resistance. This change is meant to make lower resistance values more appealing, without changing the overall balance of high end resistances. For example, at 25 points of Resistance in Classic at level 60 vs a skull level boss you had an average resist of 5.95%. Now on Epoch that equates to 6.71%.

After that 63rd resistance point, it now follows the logic used in Classic for calculating your average resist.

Partial resists are dealt in increments of 10%. You can partially resist 0%, 10%, 20%, 30%, 40%, 50%, 60%, 70%, or 80% of an attack, based on your resistance. 80% was not possible in Wrath of the Lich King due to heavier diminishing returns on the stat, but it is possible here. You will also always partially resist close to your average resist value, which makes resist damage much less RNG than in Classic.

Here's the full resistance table on Project Epoch:
![image](https://github.com/Project-Epoch/TrinityCore/assets/4321583/64988c86-01d9-4286-a5ce-9965fdae84c3)

And here's it visualized as a line graph:
![image](https://github.com/Project-Epoch/TrinityCore/assets/4321583/cec9773d-cba9-4bf2-aca7-30b0e6aea937)
