### PR TITLE
OnHealLate hook tweak

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -6601,6 +6601,7 @@ int32 Unit::HealBySpell(HealInfo& healInfo, bool critical /*= false*/)
         , TSUnit(const_cast<Unit*>(healInfo.GetHealer()))
         , TSUnit(const_cast<Unit*>(healInfo.GetTarget()))
         , healInfo.GetEffectiveHeal()
+        , healInfo.GetHeal()
         , critical
     );
     // @tswow-end


### PR DESCRIPTION
OnHealLate now also lets you read the total amount of the heal. The regular amount did not include overhealing.