### PR TITLE
Reverting Fishing to classic

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1937,15 +1937,9 @@ void GameObject::Use(Unit* user)
 
                     int32 skill = player->GetSkillValue(SKILL_FISHING);
 
-                    int32 chance;
-                    if (skill < zone_skill)
-                    {
-                        chance = int32(pow((double)skill/zone_skill, 2) * 100);
-                        if (chance < 1)
-                            chance = 1;
-                    }
-                    else
-                        chance = 100;
+                    /** @epoch-start */
+                    int32 chance = int32(skill - zone_skill + 5);
+                    /** @epoch-end */
 
                     int32 roll = irand(1, 100);
 
@@ -1958,7 +1952,9 @@ void GameObject::Use(Unit* user)
 
                     // If fishing skill is high enough, or if fishing on a pool, send correct loot.
                     // Fishing pools have no skill requirement as of patch 3.3.0 (undocumented change).
-                    if (chance >= roll || fishingPool)
+                    /** @epoch-start */
+                    if (chance >= roll) //|| fishingPool)
+                    /** @epoch-end */
                     {
                         /// @todo I do not understand this hack. Need some explanation.
                         // prevent removing GO at spell cancel

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5904,10 +5904,9 @@ uint8 GetFishingStepsNeededToLevelUp(uint32 SkillValue)
     if (SkillValue < 75)
         return 1;
 
-    if (SkillValue <= 300)
-        return SkillValue / 44;
-
-    return SkillValue / 31;
+    // @epoch-start
+    return SkillValue / 20;
+    // @epoch-end
 }
 
 bool Player::UpdateFishingSkill()
@@ -5924,10 +5923,12 @@ bool Player::UpdateFishingSkill()
 
     if (m_fishingSteps >= stepsNeededToLevelUp)
     {
-        m_fishingSteps = 0;
-
+        // @epoch-start
+        //m_fishingSteps = 0; // moved down to UpdateSkillPro so the steps only reset if the skillup was a success
         uint32 gathering_skill_gain = sWorld->getIntConfig(CONFIG_SKILL_GAIN_GATHERING);
-        return UpdateSkillPro(SKILL_FISHING, 100*10, gathering_skill_gain);
+        
+        return UpdateSkillPro(SKILL_FISHING, 75*10, gathering_skill_gain);
+        // @epoch-end
     }
 
     return false;
@@ -5970,6 +5971,12 @@ bool Player::UpdateSkillPro(uint16 SkillId, int32 Chance, uint32 step)
 
     if (Roll <= Chance)
     {
+        // @epoch-start
+        if (SkillId == SKILL_FISHING)
+        {
+            m_fishingSteps = 0;
+        }
+        // @epoch-end
         uint32 new_value = SkillValue+step;
         if (new_value > MaxValue)
             new_value = MaxValue;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -1353,6 +1353,24 @@ void Spell::SelectImplicitCasterDestTargets(SpellEffectInfo const& spellEffectIn
                 return;
             }
 
+            /** @epoch-start */
+            SpellCastResult scriptCheck = SPELL_CAST_OK;
+            FIRE_ID(m_spellInfo->events.id
+                , Spell, OnCheckFishingCast
+                , TSSpell(this)
+                , TSWorldObject(m_caster)
+                , TSNumber<uint32>(liquidData.type_flags)
+                , TSMutableNumber<uint8>(reinterpret_cast<uint8_t*>(&scriptCheck))
+            );
+            if (scriptCheck != SPELL_CAST_OK)
+            {
+                SendCastResult(scriptCheck);
+                SendChannelUpdate(0);
+                finish(false);
+                return;
+            }
+            /** @epoch-end */
+
             dest = SpellDestination(x, y, liquidLevel, m_caster->GetOrientation());
             break;
         }

--- a/src/server/shared/SharedDefines.h
+++ b/src/server/shared/SharedDefines.h
@@ -3862,6 +3862,14 @@ enum WorldState : uint32
     WS_DAILY_CALENDAR_DELETION_OLD_EVENTS_TIME = 20009,      // Next daily calendar deletions of old events time
 };
 
+enum LiquidTypes : uint32
+{
+    LIQUID_TYPE_WATER =       0x01,
+    LIQUID_TYPE_OCEAN =       0x02,
+    LIQUID_TYPE_MAGMA =       0x04,
+    LIQUID_TYPE_SLIME =       0x08,
+};
+
 namespace Trinity
 {
 namespace Impl


### PR DESCRIPTION
Chance of obtaining fish from fishing and the chance of receiving a skillup when successfully catching a fish have been reverted to 1.12 chances. The speed in which you catch fish has been kept in its 3.3.5 state, and so has junk fishing loot.

Fishing from a pool of fish no longer guarantees a catch regardless of your fishing skill, as that was a change made in patch 3.3.0.

Added new TSWoW hook for checking your fishing cast, allowing you to make a fishing cast fail. Includes the liquidtype that you're attempting to fish in.

Added LiquidTypes enum

internal note: It's my belief that TrinityCore actually has a better implementation than Vmangos, so its been kept mostly intact. TC uses a system called "fishingsteps" which is the amount of times you have to catch a fish before your next skillup. Vmangos uses pure chance. It's well theorized by many sources, such as El's Anglin', that it's likely WoW uses a Fishing Steps-like system. However it's supposed to be an average number of catches, not a set number. Due to that I changed it so that we still use fishingsteps but when you reach the required number of steps each cast now has a 75% chance of skilling you up. It's not perfectly blizzlike, but its close enough, especially since the whole system is speculation regardless. The values used are estimated using El's Anglin' archives and old/Classic Wowhead comments.