### PR TITLE
Health and Power Regeneration Rewrite

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -263,7 +263,7 @@ Creature::Creature(bool isWorldObject): Unit(isWorldObject), MapObject(), m_grou
     m_defaultMovementType(IDLE_MOTION_TYPE), m_spawnId(0), m_equipmentId(0), m_originalEquipmentId(0), m_AlreadyCallAssistance(false), m_AlreadySearchedAssistance(false), m_cannotReachTarget(false), m_cannotReachTimer(0),
     m_meleeDamageSchoolMask(SPELL_SCHOOL_MASK_NORMAL), m_originalEntry(0), m_homePosition(), m_transportHomePosition(), m_creatureInfo(nullptr), m_creatureData(nullptr), m_detectionDistance(20.0f), _waypointPathId(0),
     m_formation(nullptr), m_triggerJustAppeared(true), m_respawnCompatibilityMode(false), _lastDamagedTime(0),
-    _currentWaypointNodeInfo(0, 0), _regenerateHealth(true), _regenerateHealthLock(false), _isMissingCanSwimFlagOutOfCombat(false), m_assistanceTimer(0)
+    _currentWaypointNodeInfo(0, 0), _regenerateHealth(true), _regenerateHealthLock(false), _isMissingCanSwimFlagOutOfCombat(false), m_assistanceTimer(0), m_forcePowerRegen(false)
 {
     m_valuesCount = UNIT_END;
 
@@ -1026,7 +1026,7 @@ void Creature::RegenerateHealth()
 
 void Creature::RegeneratePower(float timerMultiplier)
 {
-    if (!HasUnitFlag2(UNIT_FLAG2_REGENERATE_POWER))
+    if (!HasUnitFlag2(UNIT_FLAG2_REGENERATE_POWER) && ! m_forcePowerRegen)
         return;
 
     Powers powerType = GetPowerType();

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1012,20 +1012,6 @@ void Creature::Update(uint32 diff)
     }
 }
 
-bool Creature::IsFreeToMove()
-{
-    uint32 moveFlags = m_movementInfo.GetMovementFlags();
-    // Do not reposition ourself when we are not allowed to move
-    if ((IsMovementPreventedByCasting() || isMoving() || !CanFreeMove()) &&
-        (GetMotionMaster()->GetCurrentMovementGeneratorType() != CHASE_MOTION_TYPE ||
-        moveFlags & MOVEMENTFLAG_SPLINE_ENABLED))
-    {
-        return false;
-    }
-
-    return true;
-}
-
 void Creature::Regenerate(Powers power)
 {
     uint32 curValue = GetPower(power);
@@ -1116,6 +1102,20 @@ void Creature::RegenerateHealth()
     addvalue += GetTotalAuraModifier(SPELL_AURA_MOD_REGEN) * CREATURE_REGEN_INTERVAL  / (5 * IN_MILLISECONDS);
 
     ModifyHealth(addvalue);
+}
+
+bool Creature::IsFreeToMove()
+{
+    uint32 moveFlags = m_movementInfo.GetMovementFlags();
+    // Do not reposition ourself when we are not allowed to move
+    if ((IsMovementPreventedByCasting() || isMoving() || !CanFreeMove()) &&
+        (GetMotionMaster()->GetCurrentMovementGeneratorType() != CHASE_MOTION_TYPE ||
+        moveFlags & MOVEMENTFLAG_SPLINE_ENABLED))
+    {
+        return false;
+    }
+
+    return true;
 }
 
 void Creature::DoFleeToGetAssistance()

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -265,7 +265,6 @@ Creature::Creature(bool isWorldObject): Unit(isWorldObject), MapObject(), m_grou
     m_formation(nullptr), m_triggerJustAppeared(true), m_respawnCompatibilityMode(false), _lastDamagedTime(0),
     _currentWaypointNodeInfo(0, 0), _regenerateHealth(true), _regenerateHealthLock(false), _isMissingCanSwimFlagOutOfCombat(false), m_assistanceTimer(0)
 {
-    m_regenTimer = CREATURE_REGEN_INTERVAL;
     m_valuesCount = UNIT_END;
 
     for (uint8 i = 0; i < MAX_CREATURE_SPELLS; ++i)
@@ -968,42 +967,7 @@ void Creature::Update(uint32 diff)
                         ai->EnterEvadeMode(CreatureAI::EVADE_REASON_NO_PATH);
             }
 
-            if (m_regenTimer > 0)
-            {
-                if (diff >= m_regenTimer)
-                    m_regenTimer = 0;
-                else
-                    m_regenTimer -= diff;
-            }
-
-            if (m_regenTimer == 0)
-            {
-                if (!IsInEvadeMode())
-                {
-                    // regenerate health if not in combat or if polymorphed)
-                    if (!IsEngaged() || IsPolymorphed())
-                        RegenerateHealth();
-                    else if (CanNotReachTarget() && m_cannotReachTimer >= CREATURE_NOPATH_REGEN_TIME)
-                    {
-                        // regenerate health if cannot reach the target and the setting is set to do so.
-                        // this allows to disable the health regen of raid bosses if pathfinding has issues for whatever reason
-                        if (sWorld->getBoolConfig(CONFIG_REGEN_HP_CANNOT_REACH_TARGET_IN_RAID) || !GetMap()->IsRaid())
-                        {
-                            RegenerateHealth();
-                            TC_LOG_DEBUG("entities.unit.chase", "RegenerateHealth() enabled because Creature cannot reach the target. Detail: {}", GetDebugInfo());
-                        }
-                        else
-                            TC_LOG_DEBUG("entities.unit.chase", "RegenerateHealth() disabled even if the Creature cannot reach the target. Detail: {}", GetDebugInfo());
-                    }
-                }
-
-                if (GetPowerType() == POWER_ENERGY)
-                    Regenerate(POWER_ENERGY);
-                else
-                    Regenerate(POWER_MANA);
-
-                m_regenTimer = CREATURE_REGEN_INTERVAL;
-            }
+            RegenerateAll(diff);
 
             break;
         }
@@ -1012,61 +976,33 @@ void Creature::Update(uint32 diff)
     }
 }
 
-void Creature::Regenerate(Powers power)
+void Creature::RegenerateAll(uint32 diff)
 {
-    uint32 curValue = GetPower(power);
-    uint32 maxValue = GetMaxPower(power);
-
-    if (!HasUnitFlag2(UNIT_FLAG2_REGENERATE_POWER))
+    m_regenTimer += diff;
+    if (m_regenTimer < REGEN_TIME_FULL_UNIT)
         return;
 
-    if (curValue >= maxValue)
-        return;
-
-    float addvalue = 0.0f;
-
-    switch (power)
+    if (!IsInEvadeMode())
     {
-        case POWER_FOCUS:
+        if (!IsEngaged() || IsPolymorphed())
+            RegenerateHealth();
+        else if (CanNotReachTarget() && m_cannotReachTimer >= CREATURE_NOPATH_REGEN_TIME)
         {
-            // For hunter pets.
-            addvalue = 24 * sWorld->getRate(RATE_POWER_FOCUS);
-            break;
-        }
-        case POWER_ENERGY:
-        {
-            // For deathknight's ghoul.
-            addvalue = 20;
-            break;
-        }
-        case POWER_MANA:
-        {
-            // Combat and any controlled creature
-            if (IsInCombat() || GetCharmerOrOwnerGUID())
+            // regenerate health if cannot reach the target and the setting is set to do so.
+            // this allows to disable the health regen of raid bosses if pathfinding has issues for whatever reason
+            if (sWorld->getBoolConfig(CONFIG_REGEN_HP_CANNOT_REACH_TARGET_IN_RAID) || !GetMap()->IsRaid())
             {
-                if (!IsUnderLastManaUseEffect())
-                {
-                    float ManaIncreaseRate = sWorld->getRate(RATE_POWER_MANA);
-                    float Spirit = GetStat(STAT_SPIRIT);
-
-                    addvalue = uint32((Spirit / 5.0f + 17.0f) * ManaIncreaseRate);
-                }
+                RegenerateHealth();
+                TC_LOG_DEBUG("entities.unit.chase", "RegenerateHealth() enabled because Creature cannot reach the target. Detail: {}", GetDebugInfo());
             }
             else
-                addvalue = maxValue / 3;
-
-            break;
+                TC_LOG_DEBUG("entities.unit.chase", "RegenerateHealth() disabled even if the Creature cannot reach the target. Detail: {}", GetDebugInfo());
         }
-        default:
-            return;
     }
 
-    // Apply modifiers (if any).
-    addvalue *= GetTotalAuraMultiplierByMiscValue(SPELL_AURA_MOD_POWER_REGEN_PERCENT, power);
+    RegeneratePower(REGEN_TIME_FULL_UNIT / 1000);
 
-    addvalue += GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_POWER_REGEN, power) * (IsHunterPet() ? PET_FOCUS_REGEN_INTERVAL : CREATURE_REGEN_INTERVAL) / (5 * IN_MILLISECONDS);
-
-    ModifyPower(power, int32(addvalue));
+    m_regenTimer -= REGEN_TIME_FULL_UNIT;
 }
 
 void Creature::RegenerateHealth()
@@ -1080,28 +1016,63 @@ void Creature::RegenerateHealth()
     if (curValue >= maxValue)
         return;
 
-    uint32 addvalue = 0;
+    uint32 addValue = 0;
 
-    // Not only pet, but any controlled creature (and not polymorphed)
-    if (GetCharmerOrOwnerGUID() && !IsPolymorphed())
+    // regenerate 33% for npc and ~13% for player controlled npc (enslave etc) ToDo: Find Regenvalue based on Spirit, might differ due to mob types
+    addValue = HasUnitFlag(UNIT_FLAG_PLAYER_CONTROLLED) ? maxValue * 0.13 : maxValue / 3;
+
+    ModifyHealth(addValue);
+}
+
+void Creature::RegeneratePower(float timerMultiplier)
+{
+    if (!HasUnitFlag2(UNIT_FLAG2_REGENERATE_POWER))
+        return;
+
+    Powers powerType = GetPowerType();
+    uint32 curValue = GetPower(powerType);
+    uint32 maxValue = GetMaxPower(powerType);
+
+    if (curValue >= maxValue)
+        return;
+
+    float addValue = 0.0f;
+
+    switch (powerType)
     {
-        float HealthIncreaseRate = sWorld->getRate(RATE_HEALTH);
-        float Spirit = GetStat(STAT_SPIRIT);
-
-        if (GetPower(POWER_MANA) > 0)
-            addvalue = uint32(Spirit * 0.25 * HealthIncreaseRate);
-        else
-            addvalue = uint32(Spirit * 0.80 * HealthIncreaseRate);
+        case POWER_MANA:
+            // Combat and any controlled creature
+            if (IsInCombat() || GetCharmerOrOwnerGUID())
+            {
+                if (!IsUnderLastManaUseEffect())
+                {
+                    float ManaIncreaseRate = sWorld->getRate(RATE_POWER_MANA);
+                    float intellect = GetStat(STAT_INTELLECT);
+                    addValue = sqrt(intellect) * OCTRegenMPPerSpirit() * ManaIncreaseRate / 5.f * timerMultiplier;
+                    if (!IsPet() && !HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED) && addValue == 0.f)
+                        addValue = (GetMaxPower(POWER_MANA) / 20) / 5.f * timerMultiplier;
+                }
+            }
+            else
+                addValue = maxValue / 3.0f;
+            break;
+        case POWER_ENERGY:
+            // ToDo: for vehicle this is different - NEEDS TO BE FIXED!
+            addValue = 20 * sWorld->getRate(RATE_POWER_ENERGY);
+            break;
+        case POWER_FOCUS:
+            addValue = 24 * sWorld->getRate(RATE_POWER_FOCUS);
+            break;
+        default:
+            return;
     }
-    else
-        addvalue = maxValue/3;
 
     // Apply modifiers (if any).
-    addvalue *= GetTotalAuraMultiplier(SPELL_AURA_MOD_HEALTH_REGEN_PERCENT);
+    addValue += GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_POWER_REGEN, powerType) / 5.f * timerMultiplier;
 
-    addvalue += GetTotalAuraModifier(SPELL_AURA_MOD_REGEN) * CREATURE_REGEN_INTERVAL  / (5 * IN_MILLISECONDS);
+    addValue *= GetTotalAuraMultiplierByMiscValue(SPELL_AURA_MOD_POWER_REGEN_PERCENT, powerType);
 
-    ModifyHealth(addvalue);
+    ModifyPower(powerType, int32(addValue));
 }
 
 bool Creature::IsFreeToMove()

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -428,8 +428,9 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         uint32 m_combatPulseDelay;                          // (secs) how often the creature puts the entire zone in combat (only works in dungeons)
 
         ReactStates m_reactState;                           // for AI, not charmInfo
-        void RegenerateHealth();
-        void Regenerate(Powers power);
+        virtual void RegenerateAll(uint32 diff);
+        void RegeneratePower(float timerMultiplier);
+        virtual void RegenerateHealth();
         MovementGeneratorType m_defaultMovementType;
         ObjectGuid::LowType m_spawnId;                               ///< For new or temporary creatures is 0 for saved it is lowguid
         uint8 m_equipmentId;

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -428,6 +428,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         uint32 m_combatPulseDelay;                          // (secs) how often the creature puts the entire zone in combat (only works in dungeons)
 
         ReactStates m_reactState;                           // for AI, not charmInfo
+        bool m_forcePowerRegen;
         virtual void RegenerateAll(uint32 diff);
         void RegeneratePower(float timerMultiplier);
         virtual void RegenerateHealth();

--- a/src/server/game/Entities/Creature/CreatureData.h
+++ b/src/server/game/Entities/Creature/CreatureData.h
@@ -284,8 +284,6 @@ struct TC_GAME_API CreatureMovementData
     std::string ToString() const;
 };
 
-static const uint32 CREATURE_REGEN_INTERVAL = 2 * IN_MILLISECONDS;
-static const uint32 PET_FOCUS_REGEN_INTERVAL = 4 * IN_MILLISECONDS;
 static const uint32 CREATURE_NOPATH_EVADE_TIME = 8 * IN_MILLISECONDS;
 static const uint32 CREATURE_NOPATH_REGEN_TIME = 4 * IN_MILLISECONDS;
 

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -1914,7 +1914,6 @@ bool Pet::Create(ObjectGuid::LowType guidlow, Map* map, uint32 phaseMask, uint32
         return false;
 
     // Force regen flag for player pets, just like we do for players themselves
-    SetUnitFlag2(UNIT_FLAG2_REGENERATE_POWER);
     SetSheath(SHEATH_STATE_MELEE);
 
     GetThreatManager().Initialize();

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -683,20 +683,24 @@ void Pet::RegenerateAll(uint32 diff)
     {
         if (!IsInCombat())
             RegenerateHealth();
+
+        if (getPetType() != HUNTER_PET)
+            RegeneratePower(REGEN_TIME_FULL_UNIT / 1000);
+
         m_regenTimer -= REGEN_TIME_FULL_UNIT;
     }
+
+    if (getPetType() != HUNTER_PET)
+        return;
 
     // regenerate focus for hunter pets
     if (m_focusTimer <= diff)
     {
-        RegeneratePower(4.f);
+        RegeneratePower(REGEN_TIME_FOCUS / 1000);
         m_focusTimer = REGEN_TIME_FOCUS;
     }
     else
         m_focusTimer -= diff;
-
-    if (getPetType() != HUNTER_PET)
-        return;
 
     if (m_happinessTimer <= diff)
     {
@@ -734,8 +738,6 @@ void Pet::RegenerateHealth()
         default:
             return;
     }
-
-    TC_LOG_INFO("server.loading", "Pet Regen HP - {} ({}) - OCTRegenHP: {} - Val: {}", GetName(), GetEntry(), OCTRegenHPPerSpirit(), addValue);
 
     ModifyHealth(addValue);
 }

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -42,7 +42,8 @@
 
 Pet::Pet(Player* owner, PetType type) :
     Guardian(nullptr, owner, true), m_usedTalentCount(0), m_removed(false),
-    m_happinessTimer(7500), m_petType(type), m_duration(0), m_auraRaidUpdateMask(0), m_loading(false)
+    m_happinessTimer(7500), m_petType(type), m_duration(0), m_auraRaidUpdateMask(0), m_loading(false),
+    m_focusTimer(REGEN_TIME_FOCUS)
 {
     ASSERT(GetOwner());
 
@@ -57,7 +58,6 @@ Pet::Pet(Player* owner, PetType type) :
     }
 
     m_name = "Pet";
-    m_focusRegenTimer = PET_FOCUS_REGEN_INTERVAL;
 }
 
 Pet::~Pet() = default;
@@ -667,56 +667,77 @@ void Pet::Update(uint32 diff)
                 }
             }
 
-            //regenerate focus for hunter pets or energy for deathknight's ghoul
-            if (m_focusRegenTimer)
-            {
-                if (m_focusRegenTimer > diff)
-                    m_focusRegenTimer -= diff;
-                else
-                {
-                    switch (GetPowerType())
-                    {
-                        case POWER_FOCUS:
-                            Regenerate(POWER_FOCUS);
-                            m_focusRegenTimer += PET_FOCUS_REGEN_INTERVAL - diff;
-                            if (!m_focusRegenTimer) ++m_focusRegenTimer;
-
-                            // Reset if large diff (lag) causes focus to get 'stuck'
-                            if (m_focusRegenTimer > PET_FOCUS_REGEN_INTERVAL)
-                                m_focusRegenTimer = PET_FOCUS_REGEN_INTERVAL;
-
-                            break;
-
-                        // in creature::update
-                        //case POWER_ENERGY:
-                        //    Regenerate(POWER_ENERGY);
-                        //    m_regenTimer += CREATURE_REGEN_INTERVAL - diff;
-                        //    if (!m_regenTimer) ++m_regenTimer;
-                        //    break;
-                        default:
-                            m_focusRegenTimer = 0;
-                            break;
-                    }
-                }
-            }
-
-            if (getPetType() != HUNTER_PET)
-                break;
-
-            if (m_happinessTimer <= diff)
-            {
-                LoseHappiness();
-                m_happinessTimer = 7500;
-            }
-            else
-                m_happinessTimer -= diff;
-
             break;
         }
         default:
             break;
     }
+
     Creature::Update(diff);
+}
+
+void Pet::RegenerateAll(uint32 diff)
+{
+    m_regenTimer += diff;
+    if (m_regenTimer >= REGEN_TIME_FULL_UNIT)
+    {
+        if (!IsInCombat())
+            RegenerateHealth();
+        m_regenTimer -= REGEN_TIME_FULL_UNIT;
+    }
+
+    // regenerate focus for hunter pets
+    if (m_focusTimer <= diff)
+    {
+        RegeneratePower(4.f);
+        m_focusTimer = REGEN_TIME_FOCUS;
+    }
+    else
+        m_focusTimer -= diff;
+
+    if (getPetType() != HUNTER_PET)
+        return;
+
+    if (m_happinessTimer <= diff)
+    {
+        LoseHappiness();
+        m_happinessTimer = 7500;
+    }
+    else
+        m_happinessTimer -= diff;
+}
+
+void Pet::RegenerateHealth()
+{
+    if (!CanRegenerateHealth())
+        return;
+
+    uint32 curValue = GetHealth();
+    uint32 maxValue = GetMaxHealth();
+
+    if (curValue >= maxValue)
+        return;
+
+    float HealthIncreaseRate = sWorld->getRate(RATE_HEALTH);
+
+    uint32 addValue = 0;
+
+    switch (getPetType())
+    {
+        case SUMMON_PET:
+        case HUNTER_PET:
+        {
+            addValue = static_cast<uint32>(std::round(OCTRegenHPPerSpirit() * HealthIncreaseRate * 5.0f));
+            break;
+        }
+
+        default:
+            return;
+    }
+
+    TC_LOG_INFO("server.loading", "Pet Regen HP - {} ({}) - OCTRegenHP: {} - Val: {}", GetName(), GetEntry(), OCTRegenHPPerSpirit(), addValue);
+
+    ModifyHealth(addValue);
 }
 
 void Pet::LoseHappiness()
@@ -1914,6 +1935,7 @@ bool Pet::Create(ObjectGuid::LowType guidlow, Map* map, uint32 phaseMask, uint32
         return false;
 
     // Force regen flag for player pets, just like we do for players themselves
+    SetUnitFlag2(UNIT_FLAG2_REGENERATE_POWER);
     SetSheath(SHEATH_STATE_MELEE);
 
     GetThreatManager().Initialize();

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -1934,8 +1934,8 @@ bool Pet::Create(ObjectGuid::LowType guidlow, Map* map, uint32 phaseMask, uint32
     if (!InitEntry(Entry))
         return false;
 
-    // Force regen flag for player pets, just like we do for players themselves
-    SetUnitFlag2(UNIT_FLAG2_REGENERATE_POWER);
+    m_forcePowerRegen = true;
+
     SetSheath(SHEATH_STATE_MELEE);
 
     GetThreatManager().Initialize();

--- a/src/server/game/Entities/Pet/Pet.h
+++ b/src/server/game/Entities/Pet/Pet.h
@@ -79,6 +79,8 @@ class TC_GAME_API Pet : public Guardian
                 return m_autospells[pos];
         }
 
+        virtual void RegenerateHealth() override;
+        void RegenerateAll(uint32 diff) override;    // overwrite Creature::RegenerateAll
         void LoseHappiness();
         HappinessState GetHappinessState();
         void GivePetXP(uint32 xp);
@@ -157,11 +159,11 @@ class TC_GAME_API Pet : public Guardian
 
     protected:
         uint32  m_happinessTimer;
+        uint32  m_focusTimer;
         PetType m_petType;
         int32   m_duration;                                 // time until unsummon (used mostly for summoned guardians and not used for controlled pets)
         uint64  m_auraRaidUpdateMask;
         bool    m_loading;
-        uint32  m_focusRegenTimer;
 
         std::unique_ptr<DeclinedName> m_declinedname;
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -544,7 +544,7 @@ bool Player::Create(ObjectGuid::LowType guidlow, CharacterCreateInfo* createInfo
         SetPvpFlag(UNIT_BYTE2_FLAG_PVP);
         SetUnitFlag(UNIT_FLAG_PLAYER_CONTROLLED);
     }
-    SetUnitFlag2(UNIT_FLAG2_REGENERATE_POWER);
+
     SetModCastingSpeed(1.0f);               // fix cast time showed in spell tooltip on client
     SetHoverHeight(1.0f);            // default for players in 3.0.3
 
@@ -2881,8 +2881,6 @@ void Player::InitStatsForLevel(bool reapplyMods)
         UNIT_FLAG_CONFUSED       | UNIT_FLAG_FLEEING      | UNIT_FLAG_UNINTERACTIBLE   |
         UNIT_FLAG_SKINNABLE      | UNIT_FLAG_MOUNT        | UNIT_FLAG_ON_TAXI          );
     SetUnitFlag(UNIT_FLAG_PLAYER_CONTROLLED);   // must be set
-
-    SetUnitFlag2(UNIT_FLAG2_REGENERATE_POWER);// must be set
 
     // cleanup player flags (will be re-applied if need at aura load), to avoid have ghost flag without ghost aura, for example.
     RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_AFK | PLAYER_FLAGS_DND | PLAYER_FLAGS_GM | PLAYER_FLAGS_GHOST | PLAYER_ALLOW_ONLY_ABILITY);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1263,7 +1263,7 @@ void Player::Update(uint32 p_time)
     {
         m_regenTimer += p_time;
         HandleFoodEmotes(p_time);
-        if (m_regenTimer >= REGEN_TIME_FULL)
+        if (m_regenTimer >= REGEN_TIME_FULL_PLAYER)
             RegenerateAll(m_regenTimer / 100 * 100);
     }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1262,6 +1262,7 @@ void Player::Update(uint32 p_time)
     if (IsAlive())
     {
         m_regenTimer += p_time;
+        HandleFoodEmotes(p_time);
         if (m_regenTimer >= REGEN_TIME_FULL)
             RegenerateAll(m_regenTimer / 100 * 100);
     }
@@ -2043,24 +2044,9 @@ bool Player::IsImmunedToSpellEffect(SpellInfo const* spellInfo, SpellEffectInfo 
     return Unit::IsImmunedToSpellEffect(spellInfo, spellEffectInfo, caster, requireImmunityPurgesEffectAttribute);
 }
 
-void Player::RegenerateAll(uint32 diff)
+void Player::HandleFoodEmotes(uint32 diff)
 {
     m_foodEmoteTimerCount += m_regenTimer;
-
-    // Not in combat or they have regeneration
-    if (!IsInCombat() || HasAuraType(SPELL_AURA_MOD_REGEN_DURING_COMBAT) ||
-            HasAuraType(SPELL_AURA_MOD_HEALTH_REGEN_IN_COMBAT))
-    {
-        RegenerateHealth(diff);
-        if (!IsInCombat() && !HasAuraType(SPELL_AURA_INTERRUPT_REGEN))
-            Regenerate(POWER_RAGE, diff);
-    }
-
-    Regenerate(POWER_ENERGY, diff);
-
-    Regenerate(POWER_MANA, diff);
-
-    m_regenTimer -= diff;
 
     // Handles the emotes for drinking and eating.
     // According to sniffs there is a background timer going on that repeats independed from the time window where the aura applies.
@@ -2092,6 +2078,24 @@ void Player::RegenerateAll(uint32 diff)
         }
         m_foodEmoteTimerCount -= 5000;
     }
+}
+
+void Player::RegenerateAll(uint32 diff)
+{
+    // Not in combat or they have regeneration
+    if (!IsInCombat() || HasAuraType(SPELL_AURA_MOD_REGEN_DURING_COMBAT) ||
+            HasAuraType(SPELL_AURA_MOD_HEALTH_REGEN_IN_COMBAT))
+    {
+        RegenerateHealth(diff);
+        if (!IsInCombat() && !HasAuraType(SPELL_AURA_INTERRUPT_REGEN))
+            Regenerate(POWER_RAGE, diff);
+    }
+
+    Regenerate(POWER_ENERGY, diff);
+
+    Regenerate(POWER_MANA, diff);
+
+    m_regenTimer -= diff;
 }
 
 void Player::Regenerate(Powers power, uint32 diff)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2052,8 +2052,8 @@ void Player::RegenerateAll(uint32 diff)
             HasAuraType(SPELL_AURA_MOD_HEALTH_REGEN_IN_COMBAT))
     {
         RegenerateHealth(diff);
-        // if (!IsInCombat() && !HasAuraType(SPELL_AURA_INTERRUPT_REGEN))
-        //     Regenerate(POWER_RAGE, diff);
+        if (!IsInCombat() && !HasAuraType(SPELL_AURA_INTERRUPT_REGEN))
+            Regenerate(POWER_RAGE, diff);
     }
 
     Regenerate(POWER_ENERGY, diff);
@@ -2122,33 +2122,24 @@ void Player::Regenerate(Powers power, uint32 diff)
         }   break;
         case POWER_RAGE:                                    // Regenerate rage
         {
-            if (!IsInCombat() && !HasAuraType(SPELL_AURA_INTERRUPT_REGEN))
-            {
-                float RageDecreaseRate = sWorld->getRate(RATE_POWER_RAGE_LOSS);
-                addvalue += -20 * RageDecreaseRate;               // 2 rage by tick (= 2 seconds => 1 rage/sec)
-            }
+            float RageDecreaseRate = sWorld->getRate(RATE_POWER_RAGE_LOSS);
+            addvalue += uint32(float(diff) / 200) * (-2.5 * RageDecreaseRate); // decay 2.5 rage per 2 seconds
+            addvalue *= GetTotalAuraMultiplierByMiscValue(SPELL_AURA_MOD_POWER_REGEN_PERCENT, power);
         }   break;
         case POWER_ENERGY:                                  // Regenerate energy (rogue)
         {
             float EnergyRate = sWorld->getRate(RATE_POWER_ENERGY);
-            addvalue += 20 * EnergyRate * m_energyRegenRate;
+            addvalue = 20 * EnergyRate * m_energyRegenRate;
         }   break;
+        case POWER_RUNE:
+        case POWER_RUNIC_POWER:
+        case POWER_FOCUS:
+        case POWER_HAPPINESS:
         case POWER_HEALTH:
             return;
         default:
             break;
     }
-
-    // // Mana regen calculated in Player::UpdateManaRegen()
-    // if (power != POWER_MANA)
-    // {
-    //     addvalue *= GetTotalAuraMultiplierByMiscValue(SPELL_AURA_MOD_POWER_REGEN_PERCENT, power);
-
-    //     // Butchery requires combat for this effect
-    //     // TODO
-    //     // if (power != POWER_RUNIC_POWER || IsInCombat())
-    //     //     addvalue += GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_POWER_REGEN, power) * ((power != POWER_ENERGY) ? m_regenTimerCount : m_regenTimer) / (5 * IN_MILLISECONDS);
-    // }
 
     if (addvalue < 0.0f)
     {

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5520,52 +5520,6 @@ float Player::GetExpertiseDodgeOrParryReduction(WeaponAttackType attType) const
     return 0.0f;
 }
 
-float Player::OCTRegenHPPerSpirit() const
-{
-    float regen = 0.0f;
-
-    float Spirit = GetStat(STAT_SPIRIT);
-    uint8 Class = GetClass();
-
-    switch (Class)
-    {
-        case CLASS_DRUID:   regen = (Spirit * 0.11 + 1);    break;
-        case CLASS_HUNTER:  regen = (Spirit * 0.43 - 5.5);  break;
-        case CLASS_MAGE:    regen = (Spirit * 0.11 + 1);    break;
-        case CLASS_PALADIN: regen = (Spirit * 0.25);        break;
-        case CLASS_PRIEST:  regen = (Spirit * 0.15 + 1.4);  break;
-        case CLASS_ROGUE:   regen = (Spirit * 0.84 - 13);   break;
-        case CLASS_SHAMAN:  regen = (Spirit * 0.28 - 3.6);  break;
-        case CLASS_WARLOCK: regen = (Spirit * 0.12 + 1.5);  break;
-        case CLASS_WARRIOR: regen = (Spirit * 1.26 - 22.6); break;
-    }
-
-    return regen;
-}
-
-float Player::OCTRegenMPPerSpirit() const
-{
-    float addvalue = 0.0;
-
-    float Spirit = GetStat(STAT_SPIRIT);
-    uint8 Class = GetClass();
-
-    switch (Class)
-    {
-        case CLASS_DRUID:   addvalue = (Spirit / 5 + 15);   break;
-        case CLASS_HUNTER:  addvalue = (Spirit / 5 + 15);   break;
-        case CLASS_MAGE:    addvalue = (Spirit / 4 + 12.5); break;
-        case CLASS_PALADIN: addvalue = (Spirit / 5 + 15);   break;
-        case CLASS_PRIEST:  addvalue = (Spirit / 4 + 12.5); break;
-        case CLASS_SHAMAN:  addvalue = (Spirit / 5 + 17);   break;
-        case CLASS_WARLOCK: addvalue = (Spirit / 5 + 15);   break;
-    }
-
-    addvalue /= 2.0f;   // the above addvalue are given per tick which occurs every 2 seconds, hence this divide by 2
-
-    return addvalue;
-}
-
 void Player::ApplyRatingMod(CombatRating combatRating, int32 value, bool apply)
 {
     float oldRating = m_baseRatingValue[combatRating];

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -427,6 +427,8 @@ Player::Player(WorldSession* session): Unit(true)
     m_reputationMgr = new ReputationMgr(this);
 
     m_groupUpdateTimer.Reset(5000);
+
+    m_energyRegenRate = 1.f;
 }
 
 Player::~Player()
@@ -2054,7 +2056,7 @@ void Player::RegenerateAll(uint32 diff)
         //     Regenerate(POWER_RAGE, diff);
     }
 
-    // Regenerate(POWER_ENERGY, diff);
+    Regenerate(POWER_ENERGY, diff);
 
     Regenerate(POWER_MANA, diff);
 
@@ -2127,20 +2129,10 @@ void Player::Regenerate(Powers power, uint32 diff)
             }
         }   break;
         case POWER_ENERGY:                                  // Regenerate energy (rogue)
-            addvalue += 20 * sWorld->getRate(RATE_POWER_ENERGY);
-            break;
-        case POWER_RUNIC_POWER:
         {
-            if (!IsInCombat() && !HasAuraType(SPELL_AURA_INTERRUPT_REGEN))
-            {
-                float RunicPowerDecreaseRate = sWorld->getRate(RATE_POWER_RUNICPOWER_LOSS);
-                addvalue += -30 * RunicPowerDecreaseRate;         // 3 RunicPower by tick
-            }
+            float EnergyRate = sWorld->getRate(RATE_POWER_ENERGY);
+            addvalue += 20 * EnergyRate * m_energyRegenRate;
         }   break;
-        case POWER_RUNE:
-        case POWER_FOCUS:
-        case POWER_HAPPINESS:
-            break;
         case POWER_HEALTH:
             return;
         default:
@@ -2898,12 +2890,6 @@ void Player::InitStatsForLevel(bool reapplyMods)
     // update level to hunter/summon pet
     if (Pet* pet = GetPet())
         pet->SynchronizeLevelWithOwner();
-
-    if (GetClass() == CLASS_ROGUE || GetClass() == CLASS_DRUID)
-    {
-        SetFloatValue(UNIT_FIELD_POWER_REGEN_FLAT_MODIFIER + POWER_ENERGY, -10.f);
-        SetFloatValue(UNIT_FIELD_POWER_REGEN_INTERRUPTED_FLAT_MODIFIER + POWER_ENERGY, -10.f);
-    }
 }
 
 void Player::SendInitialSpells()

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2056,7 +2056,7 @@ void Player::RegenerateAll(uint32 diff)
 
     // Regenerate(POWER_ENERGY, diff);
 
-    // Regenerate(POWER_MANA, diff);
+    Regenerate(POWER_MANA, diff);
 
     m_regenTimer -= diff;
 
@@ -2113,15 +2113,10 @@ void Player::Regenerate(Powers power, uint32 diff)
             bool recentCast = IsUnderLastManaUseEffect();
             float ManaIncreaseRate = sWorld->getRate(RATE_POWER_MANA);
 
-            /** @epoch-start */
-            // if (GetLevel() < 15)
-            //     ManaIncreaseRate = sWorld->getRate(RATE_POWER_MANA) * (2.066f - (GetLevel() * 0.066f));
-            /** @epoch-end */
-
             if (recentCast) // Trinity Updates Mana in intervals of 2s, which is correct
-                addvalue += GetFloatValue(UNIT_FIELD_POWER_REGEN_INTERRUPTED_FLAT_MODIFIER) *  ManaIncreaseRate * 0.001f * m_regenTimer;
+                addvalue += GetFloatValue(UNIT_FIELD_POWER_REGEN_INTERRUPTED_FLAT_MODIFIER) * ManaIncreaseRate * uint32(float(diff) / 1000);
             else
-                addvalue += GetFloatValue(UNIT_FIELD_POWER_REGEN_FLAT_MODIFIER) * ManaIncreaseRate * 0.001f * m_regenTimer;
+                addvalue += GetFloatValue(UNIT_FIELD_POWER_REGEN_FLAT_MODIFIER) * ManaIncreaseRate * uint32(float(diff) / 1000);
         }   break;
         case POWER_RAGE:                                    // Regenerate rage
         {
@@ -2152,16 +2147,16 @@ void Player::Regenerate(Powers power, uint32 diff)
             break;
     }
 
-    // Mana regen calculated in Player::UpdateManaRegen()
-    if (power != POWER_MANA)
-    {
-        addvalue *= GetTotalAuraMultiplierByMiscValue(SPELL_AURA_MOD_POWER_REGEN_PERCENT, power);
+    // // Mana regen calculated in Player::UpdateManaRegen()
+    // if (power != POWER_MANA)
+    // {
+    //     addvalue *= GetTotalAuraMultiplierByMiscValue(SPELL_AURA_MOD_POWER_REGEN_PERCENT, power);
 
-        // Butchery requires combat for this effect
-        // TODO
-        // if (power != POWER_RUNIC_POWER || IsInCombat())
-        //     addvalue += GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_POWER_REGEN, power) * ((power != POWER_ENERGY) ? m_regenTimerCount : m_regenTimer) / (5 * IN_MILLISECONDS);
-    }
+    //     // Butchery requires combat for this effect
+    //     // TODO
+    //     // if (power != POWER_RUNIC_POWER || IsInCombat())
+    //     //     addvalue += GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_POWER_REGEN, power) * ((power != POWER_ENERGY) ? m_regenTimerCount : m_regenTimer) / (5 * IN_MILLISECONDS);
+    // }
 
     if (addvalue < 0.0f)
     {
@@ -2205,11 +2200,7 @@ void Player::Regenerate(Powers power, uint32 diff)
             m_powerFraction[power] = addvalue - integerValue;
     }
 
-    // TODO
-    // if (m_regenTimerCount >= 2000)
-    //     SetPower(power, curValue);
-    // else
-    //     UpdateUInt32Value(UNIT_FIELD_POWER1 + AsUnderlyingType(power), curValue);
+    SetPower(power, curValue);
 }
 
 void Player::RegenerateHealth(uint32 diff)

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1685,6 +1685,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void ApplyManaRegenBonus(int32 amount, bool apply);
         void ApplyHealthRegenBonus(int32 amount, bool apply);
         void UpdateManaRegen();
+        void UpdateEnergyRegen();
         void UpdateRuneRegen(RuneType rune);
         uint32 GetRuneTimer(uint8 index) const { return m_runeGraceCooldown[index]; }
         void SetRuneTimer(uint8 index, uint32 timer) { m_runeGraceCooldown[index] = timer; }
@@ -2055,6 +2056,8 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         float m_homebindX;
         float m_homebindY;
         float m_homebindZ;
+
+        float m_energyRegenRate;
 
         WorldLocation GetStartPosition() const;
 

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1392,7 +1392,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void SetBindPoint(ObjectGuid guid) const;
         void SendTalentWipeConfirm(ObjectGuid guid) const;
         void ResetPetTalents();
-        void RegenerateAll(uint32 diff = REGEN_TIME_FULL);
+        void RegenerateAll(uint32 diff = REGEN_TIME_FULL_PLAYER);
         void Regenerate(Powers power, uint32 diff);
         void RegenerateHealth(uint32 diff);
         void HandleFoodEmotes(uint32 diff);

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1392,10 +1392,9 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void SetBindPoint(ObjectGuid guid) const;
         void SendTalentWipeConfirm(ObjectGuid guid) const;
         void ResetPetTalents();
-        void RegenerateAll();
-        void Regenerate(Powers power);
-        void RegenerateHealth();
-        void setRegenTimerCount(uint32 time) {m_regenTimerCount = time;}
+        void RegenerateAll(uint32 diff);
+        void Regenerate(Powers power, uint32 diff);
+        void RegenerateHealth(uint32 diff);
         void setWeaponChangeTimer(uint32 time) {m_weaponChangeTimer = time;}
 
         uint32 GetMoney() const { return GetUInt32Value(PLAYER_FIELD_COINAGE); }
@@ -2255,7 +2254,6 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
     protected:
         // Gamemaster whisper whitelist
         GuidList WhisperList;
-        uint32 m_regenTimerCount;
         uint32 m_foodEmoteTimerCount;
         float m_powerFraction[MAX_POWERS];
         uint32 m_contestedPvPTimer;

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1660,8 +1660,6 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void GetDodgeFromAgility(float &diminishing, float &nondiminishing) const;
         float GetMissPercentageFromDefense() const;
         float GetSpellCritFromIntellect() const;
-        float OCTRegenHPPerSpirit() const;
-        float OCTRegenMPPerSpirit() const;
         float GetRatingMultiplier(CombatRating cr) const;
         float GetRatingBonusValue(CombatRating cr) const;
         uint32 GetBaseSpellPowerBonus() const { return m_baseSpellPower; }

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1392,7 +1392,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void SetBindPoint(ObjectGuid guid) const;
         void SendTalentWipeConfirm(ObjectGuid guid) const;
         void ResetPetTalents();
-        void RegenerateAll(uint32 diff);
+        void RegenerateAll(uint32 diff = REGEN_TIME_FULL);
         void Regenerate(Powers power, uint32 diff);
         void RegenerateHealth(uint32 diff);
         void HandleFoodEmotes(uint32 diff);

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1395,6 +1395,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void RegenerateAll(uint32 diff);
         void Regenerate(Powers power, uint32 diff);
         void RegenerateHealth(uint32 diff);
+        void HandleFoodEmotes(uint32 diff);
         void setWeaponChangeTimer(uint32 time) {m_weaponChangeTimer = time;}
 
         uint32 GetMoney() const { return GetUInt32Value(PLAYER_FIELD_COINAGE); }

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -1245,6 +1245,15 @@ void Player::UpdateManaRegen()
     SetStatFloatValue(UNIT_FIELD_POWER_REGEN_FLAT_MODIFIER, power_regen_mp5 + power_regen);
 }
 
+void Player::UpdateEnergyRegen()
+{
+    // need to award mana based on previous rate - Patch 2.2
+    if (GetHealth() > 0) // on death we must never do this
+        RegenerateAll(std::min(uint32(REGEN_TIME_FULL), m_regenTimer));
+
+    m_energyRegenRate = GetTotalAuraMultiplierByMiscValue(SPELL_AURA_MOD_POWER_REGEN_PERCENT, POWER_ENERGY);
+}
+
 void Player::UpdateRuneRegen(RuneType rune)
 {
     if (rune >= NUM_RUNE_TYPES)

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -1208,13 +1208,8 @@ void Player::ApplyHealthRegenBonus(int32 amount, bool apply)
 
 void Player::UpdateManaRegen()
 {
-    // need to award mana based on previous rate - Patch 2.2
-    if (GetHealth() > 0) // on death we must never do this
-        RegenerateAll(std::min(uint32(REGEN_TIME_FULL), m_regenTimer));
+    float power_regen = OCTRegenMPPerSpirit();
 
-    float Intellect = GetStat(STAT_INTELLECT);
-    // Mana regen from spirit and intellect
-    float power_regen = std::sqrt(Intellect) * OCTRegenMPPerSpirit();
     // Apply PCT bonus from SPELL_AURA_MOD_POWER_REGEN_PERCENT aura on spirit base regen
     power_regen *= GetTotalAuraMultiplierByMiscValue(SPELL_AURA_MOD_POWER_REGEN_PERCENT, POWER_MANA);
 
@@ -1247,10 +1242,6 @@ void Player::UpdateManaRegen()
 
 void Player::UpdateEnergyRegen()
 {
-    // need to award mana based on previous rate - Patch 2.2
-    if (GetHealth() > 0) // on death we must never do this
-        RegenerateAll(std::min(uint32(REGEN_TIME_FULL), m_regenTimer));
-
     m_energyRegenRate = GetTotalAuraMultiplierByMiscValue(SPELL_AURA_MOD_POWER_REGEN_PERCENT, POWER_ENERGY);
 }
 

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -1208,6 +1208,10 @@ void Player::ApplyHealthRegenBonus(int32 amount, bool apply)
 
 void Player::UpdateManaRegen()
 {
+    // need to award mana based on previous rate - Patch 2.2
+    if (GetHealth() > 0) // on death we must never do this
+        RegenerateAll(std::min(uint32(REGEN_TIME_FULL), m_regenTimer));
+
     float Intellect = GetStat(STAT_INTELLECT);
     // Mana regen from spirit and intellect
     float power_regen = std::sqrt(Intellect) * OCTRegenMPPerSpirit();
@@ -1215,7 +1219,7 @@ void Player::UpdateManaRegen()
     power_regen *= GetTotalAuraMultiplierByMiscValue(SPELL_AURA_MOD_POWER_REGEN_PERCENT, POWER_MANA);
 
     // Mana regen from SPELL_AURA_MOD_POWER_REGEN aura
-    float power_regen_mp5 = (GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_POWER_REGEN, POWER_MANA) + m_baseManaRegen) / 5.0f;
+    float power_regen_mp5 = GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_POWER_REGEN, POWER_MANA) / 5.0f;
 
     // Get bonus from SPELL_AURA_MOD_MANA_REGEN_FROM_STAT aura
     AuraEffectList const& regenAura = GetAuraEffectsByType(SPELL_AURA_MOD_MANA_REGEN_FROM_STAT);
@@ -1226,6 +1230,7 @@ void Player::UpdateManaRegen()
     int32 modManaRegenInterrupt = GetTotalAuraModifier(SPELL_AURA_MOD_MANA_REGEN_INTERRUPT);
     if (modManaRegenInterrupt > 100)
         modManaRegenInterrupt = 100;
+
     // @tswow-begin
     FIRE(Player,OnUpdateManaRegen
         , TSPlayer(this)
@@ -1234,7 +1239,8 @@ void Player::UpdateManaRegen()
         , TSMutableNumber<int32>(&modManaRegenInterrupt)
     );
     // @tswow-end
-    SetStatFloatValue(UNIT_FIELD_POWER_REGEN_INTERRUPTED_FLAT_MODIFIER, power_regen_mp5 + CalculatePct(power_regen, modManaRegenInterrupt));
+
+    SetStatFloatValue(UNIT_FIELD_POWER_REGEN_INTERRUPTED_FLAT_MODIFIER, power_regen_mp5 + power_regen * modManaRegenInterrupt / 100.0f);
 
     SetStatFloatValue(UNIT_FIELD_POWER_REGEN_FLAT_MODIFIER, power_regen_mp5 + power_regen);
 }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8677,6 +8677,52 @@ int32 Unit::ModifyPower(Powers power, int32 dVal, bool withPowerUpdate /*= true*
     return gain;
 }
 
+float Unit::OCTRegenHPPerSpirit() const
+{
+    float regen = 0.0f;
+
+    float Spirit = GetStat(STAT_SPIRIT);
+    uint8 Class = GetClass();
+
+    switch (Class)
+    {
+        case CLASS_DRUID:   regen = (Spirit * 0.11 + 1);    break;
+        case CLASS_HUNTER:  regen = (Spirit * 0.43 - 5.5);  break;
+        case CLASS_MAGE:    regen = (Spirit * 0.11 + 1);    break;
+        case CLASS_PALADIN: regen = (Spirit * 0.25);        break;
+        case CLASS_PRIEST:  regen = (Spirit * 0.15 + 1.4);  break;
+        case CLASS_ROGUE:   regen = (Spirit * 0.84 - 13);   break;
+        case CLASS_SHAMAN:  regen = (Spirit * 0.28 - 3.6);  break;
+        case CLASS_WARLOCK: regen = (Spirit * 0.12 + 1.5);  break;
+        case CLASS_WARRIOR: regen = (Spirit * 1.26 - 22.6); break;
+    }
+
+    return regen;
+}
+
+float Unit::OCTRegenMPPerSpirit() const
+{
+    float addvalue = 0.0;
+
+    float Spirit = GetStat(STAT_SPIRIT);
+    uint8 Class = GetClass();
+
+    switch (Class)
+    {
+        case CLASS_DRUID:   addvalue = (Spirit / 5 + 15);   break;
+        case CLASS_HUNTER:  addvalue = (Spirit / 5 + 15);   break;
+        case CLASS_MAGE:    addvalue = (Spirit / 4 + 12.5); break;
+        case CLASS_PALADIN: addvalue = (Spirit / 5 + 15);   break;
+        case CLASS_PRIEST:  addvalue = (Spirit / 4 + 12.5); break;
+        case CLASS_SHAMAN:  addvalue = (Spirit / 5 + 17);   break;
+        case CLASS_WARLOCK: addvalue = (Spirit / 5 + 15);   break;
+    }
+
+    addvalue /= 2.0f;   // the above addvalue are given per tick which occurs every 2 seconds, hence this divide by 2
+
+    return addvalue;
+}
+
 uint32 Unit::GetAttackTime(WeaponAttackType att) const
 {
     float f_BaseAttackTime = GetFloatValue(UNIT_FIELD_BASEATTACKTIME + AsUnderlyingType(att)) / m_modAttackSpeedPct[att];

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -766,6 +766,10 @@ struct PositionUpdateInfo
 #define ATTACK_DISPLAY_DELAY 200
 #define MAX_PLAYER_STEALTH_DETECT_RANGE 30.0f               // max distance for detection targets by player
 
+// Regeneration defines
+#define REGEN_TIME_FULL         2000                            // For this time difference is computed regen value
+#define REGEN_TIME_FULL_UNIT    5000                            // For npcs
+
 class TC_GAME_API Unit : public WorldObject
 {
     friend class WorldSession;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -767,8 +767,9 @@ struct PositionUpdateInfo
 #define MAX_PLAYER_STEALTH_DETECT_RANGE 30.0f               // max distance for detection targets by player
 
 // Regeneration defines
-#define REGEN_TIME_FULL         2000                            // For this time difference is computed regen value
+#define REGEN_TIME_FULL         2000                            // For players
 #define REGEN_TIME_FULL_UNIT    5000                            // For npcs
+#define REGEN_TIME_FOCUS        4000                            // For hunter pets
 
 class TC_GAME_API Unit : public WorldObject
 {

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -767,7 +767,7 @@ struct PositionUpdateInfo
 #define MAX_PLAYER_STEALTH_DETECT_RANGE 30.0f               // max distance for detection targets by player
 
 // Regeneration defines
-#define REGEN_TIME_FULL         2000                            // For players
+#define REGEN_TIME_FULL_PLAYER  2000                            // For players
 #define REGEN_TIME_FULL_UNIT    5000                            // For npcs
 #define REGEN_TIME_FOCUS        4000                            // For hunter pets
 

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -949,7 +949,8 @@ class TC_GAME_API Unit : public WorldObject
         inline void SetFullPower(Powers power) { SetPower(power, GetMaxPower(power)); }
         // returns the change in power
         int32 ModifyPower(Powers power, int32 val, bool withPowerUpdate = true);
-
+        float OCTRegenHPPerSpirit() const;
+        float OCTRegenMPPerSpirit() const;
         uint32 GetAttackTime(WeaponAttackType att) const;
         void SetAttackTime(WeaponAttackType att, uint32 val) { SetFloatValue(UNIT_FIELD_BASEATTACKTIME + int32(att), val * m_modAttackSpeedPct[att]); }
         void ApplyAttackTimePercentMod(WeaponAttackType att, float val, bool apply);

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1790,6 +1790,9 @@ void AuraEffect::HandleAuraModShapeshift(AuraApplication const* aurApp, uint8 mo
                         {
                             CastSpellExtraArgs args(this);
                             args.AddSpellMod(SPELLVALUE_BASE_POINT0, std::min<int32>(oldPower, FurorChance));
+                            if (target->IsPlayer())
+                                target->ToPlayer()->UpdateEnergyRegen();
+                            
                             target->SetPower(POWER_ENERGY, 0);
                             target->CastSpell(target, 17099, args);
                             break;
@@ -3664,6 +3667,8 @@ void AuraEffect::HandleModPowerRegen(AuraApplication const* aurApp, uint8 mode, 
         target->ToPlayer()->UpdateManaRegen();
     else if (GetMiscValue() == POWER_RUNE)
         target->ToPlayer()->UpdateRuneRegen(RuneType(GetMiscValueB()));
+    else if (GetMiscValue() == POWER_ENERGY)
+        target->ToPlayer()->UpdateEnergyRegen();
     // other powers are not immediate effects - implemented in Player::Regenerate, Creature::Regenerate
 }
 

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -2126,11 +2126,6 @@ void AuraEffect::HandleAuraTransform(AuraApplication const* aurApp, uint8 mode, 
         // polymorph case
         if ((mode & AURA_EFFECT_HANDLE_REAL) && target->GetTypeId() == TYPEID_PLAYER && target->IsPolymorphed())
         {
-            // for players, start regeneration after 1s (in polymorph fast regeneration case)
-            // only if caster is Player (after patch 2.4.2)
-            if (GetCasterGUID().IsPlayer())
-                target->ToPlayer()->setRegenTimerCount(1*IN_MILLISECONDS);
-
             //dismount polymorphed target (after patch 2.4.2)
             if (target->IsMounted())
                 target->RemoveAurasByType(SPELL_AURA_MOUNTED);


### PR DESCRIPTION
This is essentially a breaking change and is custom tailored to Epoch so shouldn't really be PRed anywhere else but required so much to change I couldn't be bothered properly marking it as such. Womp, womp.

This PR rewrites Player, Creature and Pet health regeneration to be a hybrid between TBC and Vanilla while also fixing logic bugs and inaccuracies. As well as disabling client side features like power prediction to give a proper TBC / Vanilla style 2 second tick based health and mana regen for players.

Wrath / TBC mana and health regeneration for both players and pets feels bad so we decided to port regeneration rates for those using the Vanilla spirit to HP / MP regen formula. For this to properly reflect in any other client this requires edits that we are not providing but are relatively simple lua.

The same applies for hunter focus which now correctly displays in ticks with no client side prediction.