### PR TITLE
Under level 20 resistance calculation

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1830,12 +1830,14 @@ void Unit::HandleEmoteCommand(Emote emoteId)
 
     // level-based resistance does not apply to binary spells, and cannot be overcome by spell penetration
     // gameobject caster -- should it have level based resistance?
+    // @epoch-start
+    // Minimum level for resistance calcs is 20, anyone below level 20 is considered level 20
     if (caster && caster->GetTypeId() != TYPEID_GAMEOBJECT && (!spellInfo || !spellInfo->HasAttribute(SPELL_ATTR0_CU_BINARY_SPELL)))
-        victimResistance += std::max((float(victim->GetLevelForTarget(caster)) - float(caster->GetLevelForTarget(victim))) * 5.0f, 0.0f);
+        victimResistance += std::max((std::max(float(victim->GetLevelForTarget(caster)),20.0f) - std::max(float(caster->GetLevelForTarget(victim)),20.0f)) * 5.0f, 0.0f);
 
     static uint32 const BOSS_LEVEL = 83;
     static float const BOSS_RESISTANCE_CONSTANT = 510.0f;
-    uint32 level = victim->GetLevel();
+    uint32 level = std::max(victim->GetLevel(), uint8(20));
     float resistanceConstant = 0.0f;
 
     if (level == BOSS_LEVEL)
@@ -1843,7 +1845,6 @@ void Unit::HandleEmoteCommand(Emote emoteId)
     else
         resistanceConstant = level * 5.0f;
 
-    // @epoch-start
     //return victimResistance / (victimResistance + resistanceConstant);
     
     // If resistance is lower than 20% of cap, formula (tweaked from 1.12 base) is slightly different to make the first few points more impactful


### PR DESCRIPTION
For resistance calculations, creatures and players under level 20 are now considered level 20. This fixes an issue where resistances had extreme effects at low levels, and it appears to be the blizzlike implementation according to xpoff.com Classic Era level 19 twinking sources. Further evidence to support this implementation is the in game UI, which displays your current level as 20 if you are under level 20 when you mouse over resistances.