### PR TITLE
fix HandlePreventFleeing to cancel fears

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -2848,6 +2848,9 @@ void AuraEffect::HandleModFear(AuraApplication const* aurApp, uint8 mode, bool a
 
     Unit* target = aurApp->GetTarget();
 
+    if (target->HasAuraType(SPELL_AURA_PREVENTS_FLEEING))
+        return;
+
     target->SetControlled(apply, UNIT_STATE_FLEEING);
 }
 
@@ -2881,11 +2884,15 @@ void AuraEffect::HandlePreventFleeing(AuraApplication const* aurApp, uint8 mode,
     Unit* target = aurApp->GetTarget();
 
     // Since patch 3.0.2 this mechanic no longer affects fear effects. It will ONLY prevent humanoids from fleeing due to low health.
+
+    /* Epoch, fear can be prevented again
     if (!apply || target->HasAuraType(SPELL_AURA_MOD_FEAR))
         return;
+    */
+
     /// TODO: find a way to cancel fleeing for assistance.
     /// Currently this will only stop creatures fleeing due to low health that could not find nearby allies to flee towards.
-    target->SetControlled(false, UNIT_STATE_FLEEING);
+    target->SetControlled(!apply, UNIT_STATE_FLEEING);
 }
 
 /***************************/


### PR DESCRIPTION
(cherry picked from commit fb1966fdcad4863a8cacda884030d91bdedb17b7)

Fixed an issue where Curse of Recklessness wouldn't behave properly with an active Fear or Flee effect when applied or removed.