### PR TITLE
Normalise Hunter pet speed.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8860,8 +8860,12 @@ void Unit::UpdateSpeed(UnitMoveType mtype)
         case MOVE_FLIGHT:
         {
             // Set creature speed rate
-            if (GetTypeId() == TYPEID_UNIT)
-                speed *= ToCreature()->GetCreatureTemplate()->speed_run;    // at this point, MOVE_WALK is never reached
+            if (GetTypeId() == TYPEID_UNIT) {
+                if (!IsHunterPet())
+                    speed *= ToCreature()->GetCreatureTemplate()->speed_run;    // at this point, MOVE_WALK is never reached
+                else
+                    speed *= 1.14286f; // Is there a smarter way?
+            }
 
             // Normalize speed by 191 aura SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED if need
             /// @todo possible affect only on MOVE_RUN


### PR DESCRIPTION
Fixes an issue where hunter pets used the default speed they had in Creature Template instead of the base 114% (which most NPCs have anyway).