### PR TITLE
End visual spell channel when a Ritual Object's ritual is complete.

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2075,6 +2075,17 @@ void GameObject::Use(Unit* user)
                 if (owner)
                     owner->FinishSpell(CURRENT_CHANNELED_SPELL);
 
+                /** @epoch-start */
+                if (info->summoningRitual.animSpell)
+                {
+                    for (auto it = m_unique_users.begin(); it != m_unique_users.end(); ++it)
+                    {
+                        if (Player* target = ObjectAccessor::GetPlayer(*this, *it))
+                            target->FinishSpell(CURRENT_CHANNELED_SPELL);
+                    }
+                }
+                /** @epoch-end */
+
                 // can be deleted now, if
                 if (!info->summoningRitual.ritualPersistent)
                     SetLootState(GO_JUST_DEACTIVATED);


### PR DESCRIPTION
When a ritual object has an animation spell it should stop when the ritual is complete.

Allows us to implement custom visual feedback for assisting someone in using a Meeting Stone or with Mage/Warlock rituals.