### PR TITLE
implement Spell Queue System

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1076,8 +1076,8 @@ void Player::Update(uint32 p_time)
 
     //used to implement delayed far teleports
     SetCanDelayTeleport(true);
-    Unit::Update(p_time);
     ExecuteSortedCastRequests();
+    Unit::Update(p_time);
     SetCanDelayTeleport(false);
 
     time_t now = GameTime::GetGameTime();

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -27658,7 +27658,7 @@ bool Player::HasSameTickQueueBlock(uint32 category, bool ignore_time) const
 
 void Player::ExecuteSortedCastRequests()
 {
-    std::map<uint32, uint32> organized_list;
+    std::multimap<uint32, uint32> organized_list;
 
     if (m_pendingCasts.size())
         for (auto i = m_pendingCasts.begin(); i != m_pendingCasts.end(); ++i)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1077,6 +1077,7 @@ void Player::Update(uint32 p_time)
     //used to implement delayed far teleports
     SetCanDelayTeleport(true);
     Unit::Update(p_time);
+    ExecuteSortedCastRequests();
     SetCanDelayTeleport(false);
 
     time_t now = GameTime::GetGameTime();
@@ -3890,7 +3891,7 @@ uint32 Player::ResetTalentsCost() const
 
 void Player::IncreaseResetTalentsCostAndCounters(uint32 lastResetTalentsCost)
 {
-    
+
     if (lastResetTalentsCost > 0) // We don't want to reset the accumulated talent reset cost if we decide to temporarily enable CONFIG_NO_RESET_TALENT_COST
         m_resetTalentsCost = lastResetTalentsCost;
 
@@ -5372,7 +5373,7 @@ uint32 Player::GetShieldBlockValue() const
     // float value = std::max(0.f, (m_auraBaseFlatMod[SHIELD_BLOCK_VALUE] + GetStat(STAT_STRENGTH) * 0.5f - 10) * m_auraBasePctMod[SHIELD_BLOCK_VALUE]);
     float value = std::max(0.f, (m_auraBaseFlatMod[SHIELD_BLOCK_VALUE] + GetStat(STAT_STRENGTH) / 20 - 1) * m_auraBasePctMod[SHIELD_BLOCK_VALUE]);
     /** @epoch-end */
-    
+
     return uint32(value);
 }
 
@@ -5449,7 +5450,7 @@ float Player::GetDodgeFromAgility(float amount) const
     GtChanceToMeleeCritEntry  const* dodgeRatio = sGtChanceToMeleeCritStore.LookupEntry((pclass-1)*GT_MAX_LEVEL + level-1);
     if (dodgeRatio == nullptr || pclass > MAX_CLASSES)
         return 0.0f;
-    
+
     return (100.0f * amount * dodgeRatio->Data * crit_to_dodge[pclass - 1]);
 }
 
@@ -5809,7 +5810,7 @@ bool Player::UpdateFishingSkill()
         // @epoch-start
         //m_fishingSteps = 0; // moved down to UpdateSkillPro so the steps only reset if the skillup was a success
         uint32 gathering_skill_gain = sWorld->getIntConfig(CONFIG_SKILL_GAIN_GATHERING);
-        
+
         return UpdateSkillPro(SKILL_FISHING, 75*10, gathering_skill_gain);
         // @epoch-end
     }
@@ -27418,6 +27419,263 @@ GameClient* Player::GetGameClient() const
 {
     return GetSession()->GetGameClient();
 }
+
+bool Player::CanExecutePendingSpellCastRequest(SpellInfo const* spellInfo, bool without_queue/* = false*/)
+{
+  PendingSpellCastRequest* request = GetCastRequest(spellInfo->StartRecoveryCategory);
+
+    // already queued spell
+    if (!without_queue)
+    {
+        if (request)
+        {
+            if (!request->active)
+                return false;
+            if (!request->spell_id)
+                return false;
+        }
+    }
+
+    // gcd
+    if (GetSpellHistory()->GetRemainingGlobalCooldown(spellInfo) > uint32(0))
+    {
+        if (request && !without_queue)
+            if (GetSpellHistory()->GetRemainingGlobalCooldown(spellInfo) > SPELL_QUEUE_TIME_WINDOW)
+                CancelPendingCastRequest(spellInfo->StartRecoveryCategory);
+
+        // LOG_ERROR("sql.sql", "global cooldown for {} is {}", spellInfo->Id, GetSpellHistory()->GetGlobalCooldown(spellInfo));
+        return false;
+    }
+
+    // spell cooldown
+    if (GetSpellHistory()->GetRemainingCooldown(spellInfo) > (without_queue ? 0 : SPELL_QUEUE_TIME_WINDOW))
+        return false;
+
+    // spell in progress
+    for (CurrentSpellTypes spellSlot : {CURRENT_MELEE_SPELL, CURRENT_GENERIC_SPELL})
+        if (Spell *spell = GetCurrentSpell(spellSlot))
+        {
+            bool autoshot = false;
+
+            if (request && request->spell_id)
+                if (const SpellInfo* info = sSpellMgr->GetSpellInfo(request->spell_id))
+                    if (info->IsAutoRepeatRangedSpell())
+                        autoshot = true;
+
+            if (IsNonMeleeSpellCast(false, true, true, autoshot))
+            {
+                // LOG_ERROR("sql.sql", "CanExecutePendingSpellCastRequest false 3");
+                return false;
+            }
+        }
+    // LOG_ERROR("sql.sql", "CanExecutePendingSpellCastRequest {}) returns true", !without_queue);
+    return true;
+}
+
+bool Player::IsSpellQueueEnabled() const
+{
+    // TODO: config
+    return true;
+}
+
+void Player::RequestSpellCast(PendingSpellCastRequest castRequest, SpellInfo const* spellInfo)
+{
+    // We are overriding an already existing spell cast request so inform the client that the old cast is being replaced
+    if (auto request = GetCastRequest(spellInfo))
+        if (request->active)
+            ClearCastRequest(spellInfo);
+
+    m_pendingCasts[spellInfo->StartRecoveryCategory] = castRequest;
+}
+
+void Player::SetPendingCastRequest(PendingSpellCastRequest new_request)
+{
+    const SpellInfo* info = sSpellMgr->GetSpellInfo(new_request.spell_id);
+    if (IsSpellQueueEnabled())
+        CancelPendingCastRequest(info->StartRecoveryCategory);
+    else
+    {
+        m_pendingCasts[info->StartRecoveryCategory].active             = true;
+        m_pendingCasts[info->StartRecoveryCategory].request_packet     = new_request.request_packet;
+        m_pendingCasts[info->StartRecoveryCategory].spell_id           = new_request.spell_id;
+        m_pendingCasts[info->StartRecoveryCategory].time_requested     = new_request.time_requested;
+        m_pendingCasts[info->StartRecoveryCategory].cast_count         = new_request.cast_count;
+        m_pendingCasts[info->StartRecoveryCategory].cancel_in_progress = false;
+    }
+    return;
+}
+
+void Player::CancelPendingCastRequest(uint32 category)
+{
+    PendingSpellCastRequest *request = GetCastRequest(category);
+    if (!request)
+    {
+        // LOG_ERROR("sql.sql", "CancelPendingCastRequest category {}", category);
+        return;
+    }
+    else
+    {
+        WorldPacket packet = m_pendingCasts[category].request_packet;
+        if (WorldSession* session = GetSession())
+        {
+            m_pendingCasts[category].cancel_in_progress = true;
+            if (request->is_item)
+                session->HandleUseItemOpcode(packet);
+            else
+                session->HandleCastSpellOpcode(packet);
+        }
+        ClearCastRequest(category);
+    }
+}
+
+void Player::CancelPendingCastRequests()
+{
+    if (m_pendingCasts.size())
+    {
+        for (auto i = m_pendingCasts.begin(); i != m_pendingCasts.end(); ++i)
+        {
+
+            // if (uint32 category = i->first)
+            uint32 category = i->first; // keys cannot be null, item category is 0
+            CancelPendingCastRequest(category);
+        }
+    }
+}
+
+PendingSpellCastRequest* Player::GetCastRequest(SpellInfo const* spellInfo) const
+{
+    if (spellInfo)
+        return GetCastRequest(spellInfo->StartRecoveryCategory);
+    return nullptr;
+};
+
+PendingSpellCastRequest* Player::GetCastRequest(uint32 gcd_category) const
+{
+    auto itr = m_pendingCasts.find(gcd_category);
+    if (itr != m_pendingCasts.end())
+    {
+      const PendingSpellCastRequest* request = (&itr->second);
+      return (PendingSpellCastRequest *const)request;
+    }
+    return nullptr;
+};
+
+void Player::ClearCastRequest(SpellInfo const* info)
+{
+    if (info)
+        ClearCastRequest(info->StartRecoveryCategory);
+}
+
+void Player::ClearCastRequest(uint32 category)
+{
+        auto itr = m_pendingCasts.find(category);
+        if (itr != m_pendingCasts.end())
+            m_pendingCasts.erase(itr->first);
+}
+
+bool Player::CanRequestSpellCast(SpellInfo const* spellInfo) const
+{
+    if (!IsSpellQueueEnabled())
+        return false;
+
+    if (PendingSpellCastRequest* castRequest = GetCastRequest(spellInfo))
+        if (castRequest->active)
+            return false;
+
+    if (GetSpellHistory()->GetRemainingGlobalCooldown(spellInfo) > SPELL_QUEUE_TIME_WINDOW)
+        return false;
+
+    if (GetSpellHistory()->GetRemainingCooldown(spellInfo) > SPELL_QUEUE_TIME_WINDOW)
+        return false;
+
+    for (CurrentSpellTypes spellSlot : { CURRENT_MELEE_SPELL, CURRENT_GENERIC_SPELL })
+        if (auto spell = GetCurrentSpell(spellSlot))
+            if (spell->GetCastTimeRemaining(true) > SPELL_QUEUE_TIME_WINDOW)
+                return false;
+
+    return true;
+}
+
+void Player::ProcessPendingSpellCastRequest(uint32 category)
+{
+    PendingSpellCastRequest* request = GetCastRequest(category);
+    if (!request || !request->active)
+        return;
+    if (!CanExecutePendingSpellCastRequest(sSpellMgr->GetSpellInfo(request->spell_id)))
+        return;
+
+    WorldPacket packet = request->request_packet;
+    if (packet.empty())
+    {
+        CancelPendingCastRequest(category);
+        return;
+    }
+
+    if (WorldSession* session = GetSession())
+    {
+        // AddSameTickQueueBlock(category);
+        if (request->is_item)
+            session->HandleUseItemOpcode(packet);
+        else
+            session->HandleCastSpellOpcode(packet);
+
+        ClearCastRequest(category);
+    }
+}
+
+void Player::RemoveSameTickQueueBlock(uint32 category)
+{
+    if (m_SameTickBlockList.size())
+    {
+        if (m_SameTickBlockList.find(category) != m_SameTickBlockList.end())
+        {
+            m_SameTickBlockList.erase(category);
+            // LOG_ERROR("sql.sql", "removing same tick block from category {} at {}", category, getMSTime());
+        }
+    }
+}
+
+void Player::AddSameTickQueueBlock(uint32 category)
+{
+    // LOG_ERROR("sql.sql", "adding same tick block to category {} at {}", category, getMSTime());
+    m_SameTickBlockList[category] = getMSTime();
+}
+
+bool Player::HasSameTickQueueBlock(uint32 category, bool ignore_time) const
+{
+    if (m_SameTickBlockList.size())
+    {
+        if (m_SameTickBlockList.find(category) != m_SameTickBlockList.end())
+        {
+            auto block = m_SameTickBlockList.find(category);
+            uint32 time = block->second;
+            if (ignore_time || (GetMSTimeDiffToNow(time) < 140))
+                return true;
+        }
+    }
+    return false;
+}
+
+void Player::ExecuteSortedCastRequests()
+{
+    std::map<uint32, uint32> organized_list;
+
+    if (m_pendingCasts.size())
+        for (auto i = m_pendingCasts.begin(); i != m_pendingCasts.end(); ++i)
+                organized_list.insert({ i->second.time_requested, i->first });
+
+    if (organized_list.size())
+        for (auto i = organized_list.begin(); i != organized_list.end(); ++i)
+        {
+            // log
+            PendingSpellCastRequest* request = GetCastRequest(i->second);
+            // if (request)
+                // LOG_ERROR("sql.sql", "time: {}, spell: {}", i->first, request->spell_id);
+
+            ProcessPendingSpellCastRequest(i->second);
+        }
+}
+
 
 // @tswow-begin
 void Player::ApplyAutolearnSpells(uint32 fromLevel)

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -852,6 +852,20 @@ enum PlayerCommandStates
     CHEAT_WATERWALK = 0x10
 };
 
+
+const uint32 SPELL_QUEUE_TIME_WINDOW = 400;
+
+struct PendingSpellCastRequest
+{
+    uint32      spell_id;
+    uint32      time_requested;
+    bool        active;
+    WorldPacket request_packet;
+    bool        cancel_in_progress = false;
+    uint32      cast_count;
+    bool        is_item = false;
+};
+
 class Player;
 
 /// Holder for Battleground data
@@ -1944,6 +1958,38 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void SendLootRelease(ObjectGuid guid) const;
         void SendNotifyLootItemRemoved(uint8 lootSlot) const;
         void SendNotifyLootMoneyRemoved() const;
+
+        /*********************************************************/
+        /***               SPELL QUEUE SYSTEM                  ***/
+        /*********************************************************/
+
+        // Queues up a spell cast request that has been received via packet and processes it whenever possible.
+        PendingSpellCastRequest* GetCastRequest(SpellInfo const* spellInfo) const;
+        PendingSpellCastRequest* GetCastRequest(uint32 gcd_category) const;
+        void ClearCastRequest(SpellInfo const* info);
+        void ClearCastRequest(uint32 category);
+
+        typedef std::map<uint32 /*category*/, PendingSpellCastRequest> PendingCastList;
+        typedef std::map<uint32 /*category*/, uint32 /*time which block was set*/> SameTickQueueBlockList;
+        PendingCastList m_pendingCasts;
+        SameTickQueueBlockList m_SameTickBlockList;
+
+        void RemoveSameTickQueueBlock(uint32 category);
+        void AddSameTickQueueBlock(uint32 category);
+        bool HasSameTickQueueBlock(uint32 category, bool ignore_time) const;
+
+        void ExecuteSortedCastRequests();
+
+        bool IsSpellQueueEnabled() const;
+        void RequestSpellCast(PendingSpellCastRequest castRequest, SpellInfo const* spellInfo);
+        void SetPendingCastRequest(PendingSpellCastRequest new_request);
+        void CancelPendingCastRequest(uint32 category);
+        void CancelPendingCastRequests();
+        bool CanRequestSpellCast(SpellInfo const* spell) const;
+        void ProcessPendingSpellCastRequest(uint32 gcd_category);
+        bool CanExecutePendingSpellCastRequest(SpellInfo const* spellInfo, bool without_queue = false);
+        bool HandleProcTriggerSpell(Unit* victim, uint32 damage, uint32 absorbed, uint32 resisted, uint32 blocked, uint32 armorMitigated, AuraEffect* triggeredByAura, SpellInfo const* procSpell, uint32 procFlag, uint32 procEx, uint32 cooldown, const uint8 effectMask = MAX_EFFECT_MASK);
+        void ExecutePendingSpellCastRequest();
 
         /*********************************************************/
         /***               BATTLEGROUND SYSTEM                 ***/

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -440,6 +440,7 @@ class TC_GAME_API Spell
         bool IsAutoRepeat() const { return m_autoRepeat; }
         void SetAutoRepeat(bool rep) { m_autoRepeat = rep; }
         void ReSetTimer() { m_timer = m_casttime > 0 ? m_casttime : 0; }
+        float GetCastTimeRemaining(bool force_zero_minimum) { return (force_zero_minimum && m_timer < 0.0f) ? 0.0f : m_timer;}
         bool IsTriggered() const;
         bool IsIgnoringCooldowns() const;
         bool IsFocusDisabled() const;

--- a/src/server/game/Spells/SpellHistory.cpp
+++ b/src/server/game/Spells/SpellHistory.cpp
@@ -600,6 +600,22 @@ void SpellHistory::CancelGlobalCooldown(SpellInfo const* spellInfo)
     _globalCooldowns[spellInfo->StartRecoveryCategory] = Clock::time_point(Clock::duration(0));
 }
 
+uint32 SpellHistory::GetRemainingGlobalCooldown(SpellInfo const* spellInfo) const
+{
+    Clock::time_point end;
+    auto itr = _globalCooldowns.find(spellInfo->Id);
+    if (itr == _globalCooldowns.end())
+        return 0;
+    end = itr->second;
+
+    Clock::time_point now = GameTime::GetSystemTime();
+    if (end < now)
+        return 0;
+
+    Clock::duration remaining = end - now;
+    return uint32(std::chrono::duration_cast<std::chrono::milliseconds>(remaining).count());
+}
+
 Player* SpellHistory::GetPlayerOwner() const
 {
     return _owner->GetCharmerOrOwnerPlayerOrPlayerItself();

--- a/src/server/game/Spells/SpellHistory.h
+++ b/src/server/game/Spells/SpellHistory.h
@@ -127,6 +127,7 @@ public:
     bool HasGlobalCooldown(SpellInfo const* spellInfo) const;
     void AddGlobalCooldown(SpellInfo const* spellInfo, uint32 duration);
     void CancelGlobalCooldown(SpellInfo const* spellInfo);
+    uint32 GetRemainingGlobalCooldown(SpellInfo const* spellInfo) const;
 
     void BuildCooldownPacket(WorldPacket& data, uint8 flags, uint32 spellId, uint32 cooldown) const;
 

--- a/src/server/shared/Packets/ByteBuffer.cpp
+++ b/src/server/shared/Packets/ByteBuffer.cpp
@@ -89,6 +89,21 @@ std::string ByteBuffer::ReadCString(bool requireValidUtf8 /*= true*/)
     return value;
 }
 
+uint32 ByteBuffer::ReadPackedTime()
+{
+    auto packedDate = read<uint32>();
+    tm lt = tm();
+
+    lt.tm_min = packedDate & 0x3F;
+    lt.tm_hour = (packedDate >> 6) & 0x1F;
+    //lt.tm_wday = (packedDate >> 11) & 7;
+    lt.tm_mday = ((packedDate >> 14) & 0x3F) + 1;
+    lt.tm_mon = (packedDate >> 20) & 0xF;
+    lt.tm_year = ((packedDate >> 24) & 0x1F) + 100;
+
+    return uint32(mktime(&lt));
+}
+
 void ByteBuffer::append(uint8 const* src, size_t cnt)
 {
     ASSERT(src, "Attempted to put a NULL-pointer in ByteBuffer (pos: " SZFMTD " size: " SZFMTD ")", _wpos, size());

--- a/src/server/shared/Packets/ByteBuffer.h
+++ b/src/server/shared/Packets/ByteBuffer.h
@@ -390,6 +390,8 @@ class TC_SHARED_API ByteBuffer
             }
         }
 
+        uint32 ReadPackedTime();
+
         std::string ReadCString(bool requireValidUtf8 = true);
 
         uint8* contents()


### PR DESCRIPTION
**Changes proposed**:
- Implemented a system to queue and process spell or item cast requests
- Queue can store multiple casts prioritized by time requested (FIFO), allowing interactions such as using an item + casting a spell immediately after a cast finishes
- Window is set at [400ms, based on acore discussion](https://github.com/azerothcore/azerothcore-wotlk/issues/9300#issuecomment-977211452)

Uses [similar flow logic as TC master](https://github.com/TrinityCore/TrinityCore/pull/29409) and [Cata preservation](https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/4430863a1e9a787a3a702b58adaf4c7bb639fa29#diff-b4a23722c5b449d326b1c0e5a75f3b51de931e42e688793fd9f1d233536a02c6R17), with some structural differences. 

One key difference is that the 335a client does not send `CMSG_CAST_SPELL`  packets while on GCD, making queueing spells during casts that last the duration of GCD not possible (like instant cast corruption). Only spells queued during the end of a current spell cast (<400ms) will be queued. `CMSG_USE_ITEM` are sent when on GCD, so items can be queued during GCD e.g., casting a 1.5s spell and queuing a potion is possible


**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #50 

**Tests performed**: (Does it build, tested in-game, etc)
warlock 80 at a target dummy, trained spells, engi gloves, trinket, potion of speed

testing with a longer time window might be useful `SPELL_QUEUE_TIME_WINDOW = 400` to 1000/2000/...

tswow 78f99d423ae9

**Known issues and TODO list**:

- [ ] 
- [ ] 
