### PR TITLE
Removes the "Auction Pending" mail you receive when your Auctions sell but money hasn't arrived yet

### DIFF
--- a/src/server/game/Handlers/AuctionHouseHandler.cpp
+++ b/src/server/game/Handlers/AuctionHouseHandler.cpp
@@ -562,7 +562,9 @@ void WorldSession::HandleAuctionPlaceBid(WorldPacket& recvData)
         GetPlayer()->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_AUCTION_BID, auction->buyout);
 
         //- Mails must be under transaction control too to prevent data loss
-        sAuctionMgr->SendAuctionSalePendingMail(auction, trans);
+        // @epoch-start
+        //sAuctionMgr->SendAuctionSalePendingMail(auction, trans);
+        // @epoch-end
         sAuctionMgr->SendAuctionSuccessfulMail(auction, trans);
         sAuctionMgr->SendAuctionWonMail(auction, trans);
 


### PR DESCRIPTION
Removed the "Auction Pending" mail you receive when an item you listed on the Auction House sells. This is something that was removed in Cataclysm because it serves no purpose and tricks people into thinking there's money in their mailbox when in reality its just a note saying you'll get your money soon. You can still view pending auctions in the Auction House interface and you receive a system message any time one of your Auctions sell, this mail was redundant.

Tested to ensure this doesn't break anything, the function disabled is rather small and only used in two places.