### PR TITLE
Resistance cap fix, now based on caster's level not victim's level

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1835,15 +1835,19 @@ void Unit::HandleEmoteCommand(Emote emoteId)
     if (caster && caster->GetTypeId() != TYPEID_GAMEOBJECT && (!spellInfo || !spellInfo->HasAttribute(SPELL_ATTR0_CU_BINARY_SPELL)))
         victimResistance += std::max((std::max(float(victim->GetLevelForTarget(caster)),20.0f) - std::max(float(caster->GetLevelForTarget(victim)),20.0f)) * 5.0f, 0.0f);
 
-    static uint32 const BOSS_LEVEL = 83;
-    static float const BOSS_RESISTANCE_CONSTANT = 510.0f;
-    uint32 level = std::max(victim->GetLevel(), uint8(20));
-    float resistanceConstant = 0.0f;
-
-    if (level == BOSS_LEVEL)
-        resistanceConstant = BOSS_RESISTANCE_CONSTANT;
+    //static uint32 const BOSS_LEVEL = 83;
+    //static float const BOSS_RESISTANCE_CONSTANT = 510.0f;
+    uint32 level = 0;
+    if (caster && caster->GetTypeId() != TYPEID_GAMEOBJECT)
+        level = std::max(caster->ToUnit()->GetLevel(), uint8(20));
     else
-        resistanceConstant = level * 5.0f;
+        level = std::max(victim->GetLevel(), uint8(20));
+    float resistanceConstant = level * 5.0f;
+
+    //if (level == BOSS_LEVEL)
+    //    resistanceConstant = BOSS_RESISTANCE_CONSTANT;
+    //else
+    //    resistanceConstant = level * 5.0f;
 
     //return victimResistance / (victimResistance + resistanceConstant);
     


### PR DESCRIPTION
The Resistance cap is now calculated based on the caster's level instead of the victim's level. This is a fix not a change, however most private servers calculate the resistance cap based on the victim's level. This fix means that the Resistance cap for players against bosses is now 315 instead of 300, making it now blizzlike. This also fixes an issue where attacking a creature or player lower level than you that had resistance would cause your spells to resist significantly more than expected.

Closes https://github.com/Project-Epoch/bugtracker/issues/8344

This PR also removes the wrath of the lich king boss resistance cap, as Wrath bosses had a special exception to the normal rule. It simply doesn't need to exist on epoch.