### PR TITLE
Fishing base skill to fish in an area fix

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1935,6 +1935,11 @@ void GameObject::Use(Unit* user)
                     if (!zone_skill)
                         TC_LOG_ERROR("sql.sql", "Fishable areaId {} are not properly defined in `skill_fishing_base_level`.", subzone);
 
+                    /** @epoch-start */
+                    // Actual base skill for an area is 95 skill below the DB value. DB value is the point in which catching a fish is guaranteed.
+                    zone_skill = zone_skill - 95;
+                    /** @epoch-end */
+
                     int32 skill = player->GetSkillValue(SKILL_FISHING);
 
                     /** @epoch-start */


### PR DESCRIPTION
Fixed an issue wherein fishing skill requirements for areas were significantly higher than intended.

As a more detailed technical answer, lets look at the Bay of Storms in Azshara for example. It requires 330 fishing to be able to catch any fish there, and at 425 it becomes guaranteed that you won't catch junk. In the DB it lists 425 for that subzone. So it was accidentally requiring 425 to be able to fish there, with the guarantee being 520. This PR reduces the fetched DB value by 95 to correct this.