### PR TITLE
Allow ranged haste to apply to the entire cast time of Steady Shot an…

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -3177,11 +3177,12 @@ uint32 SpellInfo::CalcCastTime(Spell* spell /*= nullptr*/) const
 
     int32 castTime = CastTimeEntry->Base;
 
+    if (HasAttribute(SPELL_ATTR0_REQ_AMMO) && (!IsAutoRepeatRangedSpell()))
+        castTime += 500;
+
     if (spell)
         spell->GetCaster()->ModSpellCastTime(this, castTime, spell);
 
-    if (HasAttribute(SPELL_ATTR0_REQ_AMMO) && (!IsAutoRepeatRangedSpell()))
-        castTime += 500;
 
     return (castTime > 0) ? uint32(castTime) : 0;
 }


### PR DESCRIPTION
…d Aimed Shot.

Allow the hidden 0.5 sec cast time for Steady Shot and Aimed Shot to benefit from ranged haste.

Solves https://github.com/Project-Epoch/bugtracker/issues/7207

Note: Unsure if Multi-Shot should be affected by haste too. As it stands, Multi-Shot does not have an ability attribute flag so ModSpellCastTime() does not apply ranged haste to its 0.5 sec cast time. If you want to add it, either apply the attribute to Multi-Shot or manually tackle it inside ModSpellCastTime.