### PR TITLE
Allow persistent area auras to apply all of their effects upon creation.

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -730,7 +730,7 @@ void Aura::UpdateTargetMap(Unit* caster, bool apply)
 
             if (aurApp)
             {
-                aurApp->UpdateApplyEffectMask(aurApp->GetEffectsToApply() & ~itr->second, true); // aura is already applied, this means we need to update effects of current application
+                aurApp->UpdateApplyEffectMask(itr->second, true); // aura is already applied, this means we need to update effects of current application
                 itr = targets.erase(itr);
             }
             else

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1748,7 +1748,9 @@ void Spell::EffectPersistentAA()
         return;
 
     ASSERT(_dynObjAura->GetDynobjOwner());
-    _dynObjAura->_ApplyEffectForTargets(effectInfo->EffectIndex);
+    for (size_t i = 0; i < m_spellInfo->GetEffects().size(); ++i)
+        if (!m_spellInfo->GetEffect(SpellEffIndex(i)).IsEffect(SPELL_EFFECT_NONE))
+            _dynObjAura->_ApplyEffectForTargets(i);
 }
 
 void Spell::EffectEnergize()


### PR DESCRIPTION
This fixes the issue where the area auras do not instantly apply their effects.

Actually, they were only applying the last SPELL_EFFECT_PERSISTENT_AREA_AURA;
Flare and Frost Trap have 2 and 3 SPELL_EFFECT_PERSISTENT_AREA_AURA effects
respectively, so only the last one would be applied.

The previous fix would just cause the aura to apply briefly, and then
the aura would be unapplied until the next UPDATE_TARGET_MAP_INTERVAL.

Solves https://github.com/Project-Epoch/TrinityCore/issues/59
