### PR TITLE
Bypass CheckCasterAuras if the caster is not a unit.

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6357,6 +6357,9 @@ SpellCastResult Spell::CheckPetCast(Unit* target)
 
 SpellCastResult Spell::CheckCasterAuras(uint32* param1) const
 {
+    if (!m_caster->IsUnit())
+        return SPELL_CAST_OK;
+
     Unit* unitCaster = (m_originalCaster ? m_originalCaster : m_caster->ToUnit());
     if (!unitCaster)
         return SPELL_CAST_OK;


### PR DESCRIPTION
This should solve hunter traps failing when the hunter is under any form of CC.

As it stands in TrinityCore at the moment, m_originalCaster seems to point to the Player both for the hunter casts and the trap casts, such that the trap's spell cast will be checked for the hunter's caster auras. Changing this might require up cleaning up code in a lot of other places, so we just do an *actually proper* check for a unit caster and we bail if the caster is a game object (i.e. a trap).

Solves issues like https://github.com/Project-Epoch/bugtracker/issues/2823