### PR TITLE
Let melee swing go through if next melee swing spell fails.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -2193,9 +2193,13 @@ void Unit::AttackerStateUpdate(Unit* victim, WeaponAttackType attType, bool extr
 
     // melee attack spell cast at main hand attack only - no normal melee dmg dealt
     if (attType == BASE_ATTACK && m_currentSpells[CURRENT_MELEE_SPELL] && !extra)
-        m_currentSpells[CURRENT_MELEE_SPELL]->cast();
-    else
     {
+        m_currentSpells[CURRENT_MELEE_SPELL]->cast();
+        Spell* spell = m_currentSpells[CURRENT_MELEE_SPELL];
+        if (!spell || !spell->m_spellInfo->IsNextMeleeSwingSpell() || spell->isSuccessCast())
+            return;
+    }
+
         // attack can be redirected to another target
         victim = GetMeleeHitRedirectTarget(victim);
 
@@ -2220,7 +2224,6 @@ void Unit::AttackerStateUpdate(Unit* victim, WeaponAttackType attType, bool extr
         else
             TC_LOG_DEBUG("entities.unit", "AttackerStateUpdate: (NPC)    {} attacked {} for {} dmg, absorbed {}, blocked {}, resisted {}.",
                 GetGUID().ToString(), victim->GetGUID().ToString(), dmgInfo.GetDamage(), dmgInfo.GetAbsorb(), dmgInfo.GetBlock(), dmgInfo.GetResist());
-    }
 }
 
 void Unit::HandleProcExtraAttackFor(Unit* victim, uint32 count)

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4007,6 +4007,8 @@ void Spell::update(uint32 difftime)
 
 void Spell::finish(bool ok)
 {
+    m_successCast = ok;
+
     if (m_spellState == SPELL_STATE_FINISHED)
         return;
     m_spellState = SPELL_STATE_FINISHED;

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -343,6 +343,8 @@ class TC_GAME_API Spell
         SpellCastResult CheckCast(bool strict, uint32* param1 = nullptr, uint32* param2 = nullptr);
         SpellCastResult CheckPetCast(Unit* target);
 
+        bool isSuccessCast() const { return m_successCast; }
+
         // handlers
         void handle_immediate();
         uint64 handle_delayed(uint64 t_offset);
@@ -516,6 +518,7 @@ class TC_GAME_API Spell
         bool m_canReflect;                                  // can reflect this spell?
         bool m_autoRepeat;
         uint8 m_runesState;
+        bool m_successCast = false;
 
         uint8 m_delayAtDamageCount;
         /** @epoch-start */


### PR DESCRIPTION
Implement a small check so that if the swing spell (like heroic strike) fails the normal melee swing goes through.

vmangos, cmangos and AC all fundamentally do the same thing; check whether the swing spell fails. vmangos is probably the simplest/cleanest to adopt (at the cost of 1 more variable/method under Spell)

Tested with warrior heroic strike successfully; also checked extra attack procs with sword spec, they seem to still work.

Solves issues like https://github.com/Project-Epoch/bugtracker/issues/8331