### PR TITLE
Force non-caster pets to chase into melee.

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -48,6 +48,8 @@ PetAI::PetAI(Creature* creature) : CreatureAI(creature), _tracker(TIME_INTERVAL_
     if (!me->GetCharmInfo())
         throw InvalidAIException("Creature doesn't have a valid charm info");
 
+    m_bMeleeAttack = !(me->GetEntry() == 416 || me->GetEntry() == 510 || me->GetEntry() == 37994);
+
     UpdateAllies();
 }
 
@@ -83,18 +85,17 @@ void PetAI::UpdateAI(uint32 diff)
 
         // Check before attacking to prevent pets from leaving stay position
         /** @epoch-start */
-        bool canMelee = ! (me->GetEntry() == 416 || me->GetEntry() == 510 || me->GetEntry() == 37994); // Imp / Water Ele
         if (me->GetCharmInfo()->HasCommandState(COMMAND_STAY))
         {
             if (me->GetCharmInfo()->IsCommandAttack() || (me->GetCharmInfo()->IsAtStay() && me->IsWithinMeleeRange(me->GetVictim())))
             {
-                if (canMelee)
+                if (m_bMeleeAttack)
                     DoMeleeAttackIfReady();
             }
         }
         else
         {
-            if (canMelee)
+            if (m_bMeleeAttack)
                 DoMeleeAttackIfReady();
         }
         /** @epoch-end */
@@ -436,7 +437,7 @@ void PetAI::DoAttack(Unit* target, bool chase)
                 me->GetMotionMaster()->Remove(FOLLOW_MOTION_TYPE);
 
             // Pets with ranged attacks should not care about the chase angle at all.
-            float chaseDistance = me->GetPetChaseDistance();
+            float chaseDistance = m_bMeleeAttack ? 0.f : me->GetPetChaseDistance();
             float angle = chaseDistance == 0.f && target->GetTypeId() != TYPEID_PLAYER && !target->IsPet() ? float(M_PI) : 0.f;
             float tolerance = chaseDistance == 0.f ? float(M_PI_4) : float(M_PI * 2);
             me->GetMotionMaster()->MoveChase(target, ChaseRange(0.f, chaseDistance), ChaseAngle(angle, tolerance));

--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -256,7 +256,9 @@ class TC_GAME_API UnitAI
         virtual void OnGameEvent(bool /*start*/, uint16 /*eventId*/) { }
 
         virtual std::string GetDebugInfo() const;
-
+    protected:
+        // Used only for PetAI at the moment
+        bool   m_bMeleeAttack;                                     // If we allow melee auto attack
     private:
         UnitAI(UnitAI const& right) = delete;
         UnitAI& operator=(UnitAI const& right) = delete;


### PR DESCRIPTION
Solve an issue where non-caster pets had long range abilities (like wind serpent Lightning Breath) and their AI would break since they would be ordered to MoveChase up to their max range instead of melee.

Note: GetPetChaseDistance is rather obsolete now, since we only access it for caster pets, and epoch-core has the distance hardcoded to 20y for them.


PR Notes: The check done is similar to VMangos, on vanilla the only caster pet is Imp (entry 416). They also hardcode the chase distance for caster pet to 25 yards.

I moved the canMelee variable from being calculated every PetAI::Update tick to a member under UnitAI; you can restrict its scope if you wish to PetAI only; On Vmangos they have this boolean variable for every creature by checking CREATURE_STATIC_FLAG_NO_MELEE and it is under the unified CreatureAI; they check it when calling Attack()
On TC for some reason there is UnitAI and also CreatureAI, so I placed the member under UnitAI (in slim hopes of unification + removing the hardcoded melee checks under Attack() ); as mentioned, you can restrict the scope of the member.

Tested using Tyr's hand mobs (praetorian especially) and Engi helmet. Imp and Water elemental still work, and obey the MoveChase restriction.
Should hopefully solve issues like https://github.com/Project-Epoch/bugtracker/issues/2849