### PR TITLE
Do not turn off CommandAttack if the pet fails a manually cast spell.

### DIFF
--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -379,9 +379,10 @@ void WorldSession::HandlePetActionHelper(Unit* pet, ObjectGuid guid1, uint32 spe
                 spell->finish(false);
                 delete spell;
 
+                // Commenting out, we probably should check result and clear flags accordingly (TODO?)
                 // reset specific flags in case of spell fail. AI will reset other flags
-                if (pet->GetCharmInfo())
-                    pet->GetCharmInfo()->SetIsCommandAttack(false);
+                //if (pet->GetCharmInfo())
+                    //pet->GetCharmInfo()->SetIsCommandAttack(false);
             }
             break;
         }


### PR DESCRIPTION
Should solve issues like autocast AI breaking if we manually cast a spell and it fails. Potential for more checks in the future depending on the spell result?

Notes: I am fairly certain that issues like https://github.com/Project-Epoch/bugtracker/issues/4537 break because of the lines in this commit. Try as I might I was not able to find out what the reason might be for setting the CommandAttack to false if we fail a spell? Played around with a few pets and it seemed to not break anything... in the future there's space for checking the result and clearing specific flags, potentially expanding this to allow forced spells etc (see AC)