### PR TITLE
Allow Feign Death to roll against spell hit.

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -2232,6 +2232,7 @@ void AuraEffect::HandleFeignDeath(AuraApplication const* aurApp, uint8 mode, boo
                         target->MagicSpellHitResult(pCreature, GetSpellInfo()) != SPELL_MISS_NONE)
                     {
                         success = false;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
Roll individually against all the entries in the caster's threat table and within aggro radius.
Any spell fail leads to a resist against all of entries.

Ignore players and player owned creatures in the spell roll.

Based on vmangos/cmangos-tbc... which have tidier implementations.