### PR TITLE
Add the owner of a pet or charmed unit on the threat list of a creature.

### DIFF
--- a/src/server/game/Combat/ThreatManager.cpp
+++ b/src/server/game/Combat/ThreatManager.cpp
@@ -49,6 +49,14 @@ class ThreatManager::Heap : public boost::heap::fibonacci_heap<ThreatReference c
 
 void ThreatReference::AddThreat(float amount)
 {
+    // Even if amount is 0, we still want to attack the owner (e.g. pet/totem enters combat, doesn't attack and dies)
+    if (GetOwner() && amount >= 0)
+    {
+        Unit *pVictimOwner = GetVictim()->GetCharmerOrOwner(); // Do for charmed units too
+        if (pVictimOwner && GetOwner()->_IsTargetAcceptable(pVictimOwner)) {
+            GetOwner()->GetThreatManager().AddThreat(pVictimOwner, 0.0f);
+        }
+    }
     if (amount == 0.0f)
         return;
     _baseAmount = std::max<float>(_baseAmount + amount, 0.0f);


### PR DESCRIPTION
This solves most of the cases where creatures would reset after killing your pet/totem/charmed unit.

Sort of similar to vMangos code in void
HostileReference::addThreat(float pMod).

If I am not mistaken, this threat will be added on combat start and on every pet attack.

Tested with hunter/mage/warlock pets, totems and charmed creatures with Engi helmet.