### PR TITLE
Add some charm fixes.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12012,6 +12012,8 @@ bool Unit::SetCharmedBy(Unit* charmer, CharmType type, AuraApplication const* au
     // Set charmed
     charmer->SetCharm(this, true);
 
+    StopAttackingInvalidTarget();
+
     if (Player* player = ToPlayer())
     {
         if (player->isAFK())
@@ -12148,6 +12150,8 @@ void Unit::RemoveCharmedBy(Unit* charmer)
 
     charmer->SetCharm(this, false);
     m_combatManager.RevalidateCombat();
+
+    StopAttackingInvalidTarget();
 
     Player* playerCharmer = charmer->ToPlayer();
     if (playerCharmer)
@@ -13601,6 +13605,37 @@ void Unit::StopAttackFaction(uint32 faction_id)
 
     for (Unit* minion : m_Controlled)
         minion->StopAttackFaction(faction_id);
+}
+
+void Unit::StopAttackingInvalidTarget()
+{
+    AttackerSet const& attackers = getAttackers();
+    for (AttackerSet::const_iterator itr = attackers.begin(); itr != attackers.end();)
+    {
+        Unit* attacker = (*itr);
+        if (!attacker->IsValidAttackTarget(this))
+        {
+            attacker->AttackStop();
+            if (attacker->GetTypeId() == TYPEID_PLAYER)
+            {
+                attacker->ToPlayer()->SendAttackSwingCancelAttack();
+            }
+
+            for (Unit* controled : attacker->m_Controlled)
+            {
+                if (controled->GetVictim() == this && !controled->IsValidAttackTarget(this))
+                {
+                    controled->AttackStop();
+                }
+            }
+
+            itr = attackers.begin();
+        }
+        else
+        {
+            ++itr;
+        }
+    }
 }
 
 void Unit::OutDebugInfo() const

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11963,6 +11963,9 @@ bool Unit::SetCharmedBy(Unit* charmer, CharmType type, AuraApplication const* au
 
     CastStop();
     AttackStop();
+    // If a priest Mind Controls a unit, do not clear combat
+    if (type != CHARM_TYPE_POSSESS)
+       CombatStop();
 
     Player* playerCharmer = charmer->ToPlayer();
 

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -871,6 +871,7 @@ class TC_GAME_API Unit : public WorldObject
         void CombatStop(bool includingCast = false, bool mutualPvP = true);
         void CombatStopWithPets(bool includingCast = false);
         void StopAttackFaction(uint32 faction_id);
+        void StopAttackingInvalidTarget();
         Unit* SelectNearbyTarget(Unit* exclude = nullptr, float dist = NOMINAL_MELEE_RANGE) const;
         void SendMeleeAttackStop(Unit* victim = nullptr);
         void SendMeleeAttackStart(Unit* victim);


### PR DESCRIPTION
First commit is from AC, and it solves the issue of attackers still attacking invalid targets after an MC ends (e.g. players attacking another player after an MC from a boss ends).

All credit belongs to the original author UltraNix.
Link to original commit is https://github.com/azerothcore/azerothcore-wotlk/commit/13993a0b5b45430ea7bc4868283494f0362f2a1e

The second commit is a small fix to clear combat on CHARM (and vehicles I guess, but no good way to test) type charms, solving issues like enslave demon and the hunter taming quests keeping the players in combat.

The only issue I could foresee is the threat table getting cleared for the creature/player getting charmed, getting a free threat reset out of it --> might warrant a future fix if needed.

Tested with a variety of combos between priest MC and allies/enemy players and NPCs, and Arugal MC + 2 players, and enslave demon + hunter taming quests.
