### PR TITLE
Fix Goblin Rocket Helm.

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -4484,6 +4484,12 @@ void AuraEffect::HandleAuraDummy(AuraApplication const* aurApp, uint8 mode, bool
                 //    break;
                 //}
                 // @epoch-end
+                case 22646:                             // Goblin Rocket Helmet
+                {
+                    if (caster)
+                        caster->CastSpell(caster, 13360, true);
+                    break;
+                }
                 case 37096:                                     // Blood Elf Illusion
                 {
                     if (caster)

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -4490,7 +4490,7 @@ void Spell::EffectCharge()
     if (effectHandleMode == SPELL_EFFECT_HANDLE_HIT_TARGET)
     {
         // not all charge effects used in negative spells
-        if (!m_spellInfo->IsPositive() && m_caster->GetTypeId() == TYPEID_PLAYER)
+        if (!m_spellInfo->HasAttribute(SPELL_ATTR0_STOP_ATTACK_TARGET) && !m_spellInfo->IsPositive() && m_caster->GetTypeId() == TYPEID_PLAYER)
             unitCaster->Attack(unitTarget, true);
     }
 }


### PR DESCRIPTION
First commit solves an issue where players auto attack after using the goblin rocket helmet, making it useless. 
Based on UltraNix's commit here https://github.com/azerothcore/azerothcore-wotlk/commit/e3ed2e99e67cf23baf67e132abf57432d9de4cc9

Second one adds a knockdown to the caster, taken from vmangos.
