### PR TITLE
Fix various vanish interactions.

### DIFF
--- a/src/common/Utilities/EventProcessor.h
+++ b/src/common/Utilities/EventProcessor.h
@@ -111,6 +111,8 @@ class TC_COMMON_API EventProcessor
         void ModifyEventTime(BasicEvent* event, Milliseconds newTime);
         Milliseconds CalculateTime(Milliseconds t_offset) const { return Milliseconds(m_time) + t_offset; }
 
+        std::multimap<uint64, BasicEvent*> const& GetEvents() const { return m_events; }
+
     protected:
         uint64 m_time;
         std::multimap<uint64, BasicEvent*> m_events;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -874,6 +874,9 @@ class TC_GAME_API Unit : public WorldObject
         Unit* SelectNearbyTarget(Unit* exclude = nullptr, float dist = NOMINAL_MELEE_RANGE) const;
         void SendMeleeAttackStop(Unit* victim = nullptr);
         void SendMeleeAttackStart(Unit* victim);
+        void InterruptSpellsCastedOnMe(bool killDelayed = false, bool interruptPositiveSpells = false, bool onlyIfNotStalked = false);
+        void InterruptAttacksOnMe(float dist = 0.0f, bool guard_check = false); // Interrupt auto-attacks
+
 
         void AddUnitState(uint32 f) { m_state |= f; }
         bool HasUnitState(const uint32 f) const { return (m_state & f) != 0; }

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1687,7 +1687,7 @@ void Aura::HandleAuraSpecificMods(AuraApplication const* aurApp, Unit* caster, b
                 break;
             case SPELLFAMILY_ROGUE:
                 // Remove Vanish on stealth remove
-                if (GetId() == 1784)
+                if (GetSpellInfo()->SpellFamilyFlags[0] & 0x00400000) // Stealth
                     target->RemoveAurasWithFamily(SPELLFAMILY_ROGUE, 0x0000800, 0, 0, target->GetGUID());
                 break;
             case SPELLFAMILY_PALADIN:

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -499,24 +499,6 @@ SpellValue::SpellValue(SpellInfo const* proto)
     CriticalChance = 0.0f;
 }
 
-class TC_GAME_API SpellEvent : public BasicEvent
-{
-public:
-    explicit SpellEvent(Spell* spell);
-    ~SpellEvent();
-
-    bool Execute(uint64 e_time, uint32 p_time) override;
-    void Abort(uint64 e_time) override;
-    bool IsDeletable() const override;
-    Spell const* GetSpell() const { return m_Spell.get(); }
-    Trinity::unique_weak_ptr<Spell> GetSpellWeakPtr() const { return m_Spell; }
-
-    std::string GetDebugInfo() const { return m_Spell->GetDebugInfo(); }
-
-protected:
-    Trinity::unique_trackable_ptr<Spell> m_Spell;
-};
-
 Spell::Spell(WorldObject* caster, SpellInfo const* info, TriggerCastFlags triggerFlags, ObjectGuid originalCasterGUID) :
 m_spellInfo(sSpellMgr->GetSpellForDifficultyFromSpell(info, caster)),
 m_caster((info->HasAttribute(SPELL_ATTR6_CAST_BY_CHARMER) && caster->GetCharmerOrOwner()) ? caster->GetCharmerOrOwner() : caster)

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -807,4 +807,22 @@ namespace Trinity
 
 using SpellEffectHandlerFn = void(Spell::*)();
 
+class TC_GAME_API SpellEvent : public BasicEvent
+{
+public:
+    explicit SpellEvent(Spell* spell);
+    ~SpellEvent();
+
+    bool Execute(uint64 e_time, uint32 p_time) override;
+    void Abort(uint64 e_time) override;
+    bool IsDeletable() const override;
+    Spell const* GetSpell() const { return m_Spell.get(); }
+    Trinity::unique_weak_ptr<Spell> GetSpellWeakPtr() const { return m_Spell; }
+    Spell* GetNonConstSpell() const { return m_Spell.get(); }
+    std::string GetDebugInfo() const { return m_Spell->GetDebugInfo(); }
+
+protected:
+    Trinity::unique_trackable_ptr<Spell> m_Spell;
+};
+
 #endif

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3773,6 +3773,9 @@ void Spell::EffectSanctuary()
     if (!unitTarget)
         return;
 
+    unitTarget->InterruptSpellsCastedOnMe(true);
+    unitTarget->InterruptAttacksOnMe(0.0f);
+
     if (unitTarget->GetTypeId() == TYPEID_PLAYER && !unitTarget->GetMap()->IsDungeon())
     {
         // stop all pve combat for players outside dungeons, suppress pvp combat


### PR DESCRIPTION
Core rogue mechanic --> if you vanish while a projectile is flying towards you, it causes said projectile to evade. (also works with invisibility)

Also, adds a small epoch-specific fix where the vanish buff would remain when you removed stealth aura.

The spells defined in Unit can later on be used for other effects (e.g. clean up code in Feign Death effect).

Does not work with channeled spells whose projectiles have already left the caster's hands.
It does not address the fact that contested guards should be able to see through stealth (AFAIK).
Based on vmangos code.