### PR TITLE
HACK: Handle Flare Effects on Spell Launch rather than Spell Hit.

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1716,6 +1716,11 @@ void Spell::EffectCreateRandomItem()
 void Spell::EffectPersistentAA()
 {
     if (effectHandleMode != SPELL_EFFECT_HANDLE_HIT)
+    {
+        if (!(m_spellInfo->Id == 1543 && effectHandleMode == SPELL_EFFECT_HANDLE_LAUNCH)) // Handle only Flare on Launch, return otherwise
+            return;
+    }
+    else if (m_spellInfo->Id == 1543) // Do not handle Flare on Hit, handle everything else
         return;
 
     Unit* unitCaster = GetUnitCasterForEffectHandlers();


### PR DESCRIPTION
Modify Spell:EffectPersistentAA to handle flare effects on spell launch, and ignore them on spell effect hit, keeping the behaviour for all other spells the same.

This solves the issue where flare is not applied immediately upon casting.

I say it's a hack because we manually check for flare inside this effect application. It might be the case that we can actually call this on Spell launch for all of the Persistent AA effects, but I did not want to mess with everything else.
