### PR TITLE
Prevent pet spell power from increasing physical damage abilities

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -6822,6 +6822,12 @@ uint32 Unit::SpellDamageBonusDone(Unit* victim, SpellInfo const* spellProto, uin
     // Default calculation
     if (DoneAdvertisedBenefit)
     {
+        // @epoch-start
+        // Physical spells should not gain spell damage modifiers
+        if (spellProto->GetSchoolMask() & SPELL_SCHOOL_MASK_NORMAL)
+            DoneAdvertisedBenefit = 0;
+        // @epoch-end
+
         if (coeff < 0.f)
             coeff = CalculateDefaultCoefficient(spellProto, damagetype);  // As wowwiki says: C = (Cast Time / 3.5)
 


### PR DESCRIPTION
Fixed an issue where physical pet spells, such as Claw, would benefit from the Spell Power on a pet obtained from the hunter's Ranged Attack Power.

https://github.com/Project-Epoch/bugtracker/issues/8431