### PR TITLE
Properly retrieve pet to dismiss for spells with SPELL_ATTR1_DISMISS_…

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3495,7 +3495,7 @@ void Spell::_cast(bool skipCheck)
 
     if (Unit* unitCaster = m_caster->ToUnit())
         if (m_spellInfo->HasAttribute(SPELL_ATTR1_DISMISS_PET))
-            if (Creature* pet = ObjectAccessor::GetCreature(*m_caster, unitCaster->GetPetGUID()))
+            if (Pet* pet = ObjectAccessor::GetPet(*m_caster, unitCaster->GetPetGUID()))
                 pet->DespawnOrUnsummon();
 
     PrepareTriggersExecutedOnHit();


### PR DESCRIPTION
…PET.

For some reason, the previous GetCreature function was not returning a valid pointer when a warlock would use Enslave Demon with a summoned pet, leading to the warlock having a pet + a charm. Modified to use the more restrictive GetPet (since we are expecting a Pet...)

Unsure if the better approach is to do a GetUnit and cast it into a Creature -- also worked on my testing.