### PR TITLE
Link dungeon boss loot to the players inside the dungeon.

### DIFF
--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -232,6 +232,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         bool CanGeneratePickPocketLoot() const;
         ObjectGuid GetLootRecipientGUID() const { return m_lootRecipient; }
         Player* GetLootRecipient() const;
+        ObjectGuid::LowType GetLootRecipientGroupGUID() const { return m_lootRecipientGroup; }
         Group* GetLootRecipientGroup() const;
         bool hasLootRecipient() const { return !m_lootRecipient.IsEmpty() || m_lootRecipientGroup; }
         bool isTappedBy(Player const* player) const;                          // return true if the creature is tapped by the player or a member of his party.
@@ -415,7 +416,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         static float _GetHealthMod(int32 Rank);
 
         ObjectGuid m_lootRecipient;
-        uint32 m_lootRecipientGroup;
+        ObjectGuid::LowType m_lootRecipientGroup;
 
         /// Timers
         time_t _pickpocketLootRestore;

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2791,6 +2791,9 @@ bool GameObject::IsLootAllowedFor(Player const* player) const
     if (!playerGroup || playerGroup != GetLootRecipientGroup()) // if we dont have a group we arent the recipient
         return false;                                           // if go doesnt have group bound it means it was solo killed by someone else
 
+    if (!HasAllowedLooter(player->GetGUID()))
+        return false;
+
     return true;
 }
 

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2731,33 +2731,52 @@ Group* GameObject::GetLootRecipientGroup() const
     return sGroupMgr->GetGroupByGUID(m_lootRecipientGroup);
 }
 
-void GameObject::SetLootRecipient(Unit* unit, Group* group)
+void GameObject::SetLootRecipient(Creature* creature)
 {
     // set the player whose group should receive the right
     // to loot the creature after it dies
     // should be set to nullptr after the loot disappears
-
-    if (!unit)
+    if (!creature)
     {
         m_lootRecipient.Clear();
-        m_lootRecipientGroup = group ? group->GetLowGUID() : 0;
+        m_lootRecipientGroup = 0;
+        ResetAllowedLooters();
         return;
     }
 
-    if (unit->GetTypeId() != TYPEID_PLAYER && !unit->IsVehicle())
-        return;
+    m_lootRecipient = creature->GetLootRecipientGUID();
+    m_lootRecipientGroup = creature->GetLootRecipientGroupGUID();
+    SetAllowedLooters(creature->GetAllowedLooters());
+}
 
-    Player* player = unit->GetCharmerOrOwnerPlayerOrPlayerItself();
-    if (!player)                                             // normal creature, no player involved
-        return;
+void GameObject::SetLootRecipient(Map* map)
+{
+    Group* group = nullptr;
+    Map::PlayerList const& PlayerList = map->GetPlayers();
+    for (Map::PlayerList::const_iterator i = PlayerList.begin(); i != PlayerList.end(); ++i)
+    {
+        if (Player* groupMember = i->GetSource())
+        {
+            if (groupMember->IsGameMaster() /* || groupMember->IsSpectator() */) // No spectator in TC
+                continue;
 
-    m_lootRecipient = player->GetGUID();
+            if (!m_lootRecipient)
+                m_lootRecipient = groupMember->GetGUID();
 
-    // either get the group from the passed parameter or from unit's one
-    if (group)
-        m_lootRecipientGroup = group->GetLowGUID();
-    else if (Group* unitGroup = player->GetGroup())
-        m_lootRecipientGroup = unitGroup->GetLowGUID();
+            Group* memberGroup = groupMember->GetGroup();
+            if (memberGroup && !group)
+            {
+                group = memberGroup;
+                m_lootRecipientGroup = group->GetGUID().GetCounter();
+            }
+
+            if (memberGroup == group)
+                AddAllowedLooter(groupMember->GetGUID());
+        }
+    }
+
+    if (!group)
+        AddAllowedLooter(m_lootRecipient);
 }
 
 bool GameObject::IsLootAllowedFor(Player const* player) const

--- a/src/server/game/Entities/GameObject/GameObject.h
+++ b/src/server/game/Entities/GameObject/GameObject.h
@@ -231,7 +231,8 @@ class TC_GAME_API GameObject : public WorldObject, public GridObject<GameObject>
 
         Player* GetLootRecipient() const;
         Group* GetLootRecipientGroup() const;
-        void SetLootRecipient(Unit* unit, Group* group = nullptr);
+        void SetLootRecipient(Creature* creature);
+        void SetLootRecipient(Map* map);
         bool IsLootAllowedFor(Player const* player) const;
         bool HasLootRecipient() const { return !m_lootRecipient.IsEmpty() || m_lootRecipientGroup; }
         uint32 m_groupLootTimer;                            // (msecs)timer used for group loot
@@ -357,7 +358,7 @@ class TC_GAME_API GameObject : public WorldObject, public GridObject<GameObject>
         Position m_stationaryPosition;
 
         ObjectGuid m_lootRecipient;
-        uint32 m_lootRecipientGroup;
+        ObjectGuid::LowType m_lootRecipientGroup;
         uint16 m_LootMode;                                  // bitmask, default LOOT_MODE_DEFAULT, determines what loot will be lootable
         uint32 m_lootGenerationTime;
 

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -3742,3 +3742,31 @@ template TC_GAME_API void WorldObject::GetCreatureListWithEntryInGrid(std::vecto
 template TC_GAME_API void WorldObject::GetPlayerListInGrid(std::list<Player*>&, float, bool) const;
 template TC_GAME_API void WorldObject::GetPlayerListInGrid(std::deque<Player*>&, float, bool) const;
 template TC_GAME_API void WorldObject::GetPlayerListInGrid(std::vector<Player*>&, float, bool) const;
+
+void WorldObject::AddAllowedLooter(ObjectGuid guid)
+{
+    _allowedLooters.insert(guid);
+}
+
+void WorldObject::SetAllowedLooters(GuidUnorderedSet const looters)
+{
+    _allowedLooters = looters;
+}
+
+void WorldObject::ResetAllowedLooters()
+{
+    _allowedLooters.clear();
+}
+
+bool WorldObject::HasAllowedLooter(ObjectGuid guid) const
+{
+    if (_allowedLooters.empty())
+        return true;
+
+    return _allowedLooters.find(guid) != _allowedLooters.end();
+}
+
+GuidUnorderedSet const& WorldObject::GetAllowedLooters() const
+{
+    return _allowedLooters;
+}

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -580,6 +580,12 @@ class TC_GAME_API WorldObject : public Object, public WorldLocation
         // Event handler
         EventProcessor m_Events;
 
+        void AddAllowedLooter(ObjectGuid guid);
+        void ResetAllowedLooters();
+        void SetAllowedLooters(GuidUnorderedSet const looters);
+        bool HasAllowedLooter(ObjectGuid guid) const;
+        GuidUnorderedSet const& GetAllowedLooters() const;
+
     protected:
         std::string m_name;
         bool m_isActive;
@@ -623,6 +629,8 @@ class TC_GAME_API WorldObject : public Object, public WorldLocation
         bool CanDetect(WorldObject const* obj, bool ignoreStealth, bool checkAlert = false) const;
         bool CanDetectInvisibilityOf(WorldObject const* obj) const;
         bool CanDetectStealthOf(WorldObject const* obj, bool checkAlert = false) const;
+
+        GuidUnorderedSet _allowedLooters;
 };
 
 namespace Trinity

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -18238,6 +18238,9 @@ bool Player::isAllowedToLoot(Creature const* creature) const
     else if (thisGroup != creature->GetLootRecipientGroup())
         return false;
 
+    if (!creature->HasAllowedLooter(GetGUID()))
+        return false;
+
     switch (thisGroup->GetLootMethod())
     {
         case MASTER_LOOT:

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -8534,7 +8534,7 @@ void Player::SendLoot(ObjectGuid guid, LootType loot_type)
                 if (groupRules)
                     group->UpdateLooterGuid(go, true);
 
-                loot->FillLoot(lootid, LootTemplates_Gameobject, this, !groupRules, false, go->GetLootMode());
+                loot->FillLoot(lootid, LootTemplates_Gameobject, this, !groupRules, false, go->GetLootMode(), go);
                 go->SetLootGenerationTime();
 
                 // @tswow-begin
@@ -24356,17 +24356,28 @@ void Player::RewardPlayerAndGroupAtEvent(uint32 creature_id, WorldObject* pRewar
 
 bool Player::IsAtGroupRewardDistance(WorldObject const* pRewardSource) const
 {
-    if (!pRewardSource || !IsInMap(pRewardSource))
-        return false;
-
     WorldObject const* player = GetCorpse();
     if (!player || IsAlive())
         player = this;
+
+    if (!pRewardSource || !player->IsInMap(pRewardSource))
+        return false;
 
     if (pRewardSource->GetMap()->IsDungeon())
         return true;
 
     return pRewardSource->GetDistance(player) <= sWorld->getFloatConfig(CONFIG_GROUP_XP_DISTANCE);
+}
+
+bool Player::IsAtLootRewardDistance(WorldObject const* pRewardSource) const
+{
+    if (!IsAtGroupRewardDistance(pRewardSource))
+        return false;
+
+    if (HasPendingBind())
+        return false;
+
+    return pRewardSource->HasAllowedLooter(GetGUID());
 }
 
 bool Player::IsAtRecruitAFriendDistance(WorldObject const* pOther) const

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1822,6 +1822,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void InitDisplayIds();
 
         bool IsAtGroupRewardDistance(WorldObject const* pRewardSource) const;
+        bool IsAtLootRewardDistance(WorldObject const* pRewardSource) const;
         bool IsAtRecruitAFriendDistance(WorldObject const* pOther) const;
         void RewardPlayerAndGroupAtKill(Unit* victim, bool isBattleGround);
         void RewardPlayerAndGroupAtEvent(uint32 creature_id, WorldObject* pRewardSource);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11365,7 +11365,7 @@ bool Unit::InitTamedPet(Pet* pet, uint8 level, uint32 spell_id)
                     for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
                     {
                         Player* member = itr->GetSource();
-                        if (!member || !creature->IsInMap(member))
+                        if (!member || !member->IsAtLootRewardDistance(creature))
                             continue;
 
                         player = member;
@@ -11441,7 +11441,7 @@ bool Unit::InitTamedPet(Pet* pet, uint8 level, uint32 spell_id)
                 // @tswow-begin
                 if(loot->generateNormally)
                 // @tswow-end
-                    loot->FillLoot(lootid, LootTemplates_Creature, looter, false, false, creature->GetLootMode());
+                    loot->FillLoot(lootid, LootTemplates_Creature, looter, false, false, creature->GetLootMode(), creature);
 
             if (creature->GetLootMode() > 0)
                 loot->generateMoneyLoot(creature->GetCreatureTemplate()->mingold, creature->GetCreatureTemplate()->maxgold);

--- a/src/server/game/Handlers/LootHandler.cpp
+++ b/src/server/game/Handlers/LootHandler.cpp
@@ -176,7 +176,7 @@ void WorldSession::HandleLootMoneyOpcode(WorldPacket& /*recvData*/)
                 if (!member)
                     continue;
 
-                if (player->IsAtGroupRewardDistance(member))
+                if (player->IsAtLootRewardDistance(member))
                     playersNear.push_back(member);
             }
 

--- a/src/server/game/Loot/Loot.h
+++ b/src/server/game/Loot/Loot.h
@@ -252,7 +252,7 @@ struct TC_GAME_API Loot
     void RemoveLooter(ObjectGuid GUID) { PlayersLooting.erase(GUID); }
 
     void generateMoneyLoot(uint32 minAmount, uint32 maxAmount);
-    bool FillLoot(uint32 lootId, LootStore const& store, Player* lootOwner, bool personal, bool noEmptyError = false, uint16 lootMode = LOOT_MODE_DEFAULT);
+    bool FillLoot(uint32 lootId, LootStore const& store, Player* lootOwner, bool personal, bool noEmptyError = false, uint16 lootMode = LOOT_MODE_DEFAULT, WorldObject* lootSource = nullptr);
 
     // Inserts the item into the loot (called by LootTemplate processors)
     void AddItem(LootStoreItem const & item);
@@ -264,10 +264,10 @@ struct TC_GAME_API Loot
     bool hasOverThresholdItem() const;
 
     private:
-        void FillNotNormalLootFor(Player* player, bool presentAtLooting);
+        void FillNotNormalLootFor(Player* player);
         NotNormalLootItemList* FillFFALoot(Player* player);
         NotNormalLootItemList* FillQuestLoot(Player* player);
-        NotNormalLootItemList* FillNonQuestNonFFAConditionalLoot(Player* player, bool presentAtLooting);
+        NotNormalLootItemList* FillNonQuestNonFFAConditionalLoot(Player* player);
 
         GuidSet PlayersLooting;
         NotNormalLootItemMap PlayerQuestItems;

--- a/src/server/game/Loot/LootItemStorage.cpp
+++ b/src/server/game/Loot/LootItemStorage.cpp
@@ -182,6 +182,12 @@ bool LootItemStorage::LoadStoredLoot(Item* item, Player* player)
         }
     }
 
+    // Not sure if needed in TC?
+    // if (loot->unlootedCount)
+    // {
+    //     loot->FillNotNormalLootFor(player);
+    // }
+
     // Mark the item if it has loot so it won't be generated again on open
     item->m_lootGenerated = true;
     return true;

--- a/src/server/scripts/Northrend/IcecrownCitadel/instance_icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/instance_icecrown_citadel.cpp
@@ -657,7 +657,7 @@ class instance_icecrown_citadel : public InstanceMapScript
                     case GO_CACHE_OF_THE_DREAMWALKER_10H:
                     case GO_CACHE_OF_THE_DREAMWALKER_25H:
                         if (Creature* valithria = instance->GetCreature(ValithriaDreamwalkerGUID))
-                            go->SetLootRecipient(valithria->GetLootRecipient(), valithria->GetLootRecipientGroup());
+                            go->SetLootRecipient(valithria);
                         go->RemoveFlag(GO_FLAG_LOCKED | GO_FLAG_NOT_SELECTABLE | GO_FLAG_NODESPAWN);
                         break;
                     case GO_ARTHAS_PLATFORM:
@@ -905,7 +905,10 @@ class instance_icecrown_citadel : public InstanceMapScript
                                 SetTeleporterState(teleporter, true);
 
                             if (GameObject* loot = instance->GetGameObject(GunshipArmoryGUID))
+                            {
+                                loot->SetLootRecipient(instance);
                                 loot->RemoveFlag(GO_FLAG_LOCKED | GO_FLAG_NOT_SELECTABLE | GO_FLAG_NODESPAWN);
+                            }
                         }
                         else if (state == FAIL)
                             Events.ScheduleEvent(EVENT_RESPAWN_GUNSHIP, 30s);
@@ -918,7 +921,7 @@ class instance_icecrown_citadel : public InstanceMapScript
                                 if (GameObject* loot = instance->GetGameObject(DeathbringersCacheGUID))
                                 {
                                     if (Creature* deathbringer = instance->GetCreature(DeathbringerSaurfangGUID))
-                                        loot->SetLootRecipient(deathbringer->GetLootRecipient(), deathbringer->GetLootRecipientGroup());
+                                        loot->SetLootRecipient(deathbringer);
                                     loot->RemoveFlag(GO_FLAG_LOCKED | GO_FLAG_NOT_SELECTABLE | GO_FLAG_NODESPAWN);
                                 }
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -676,7 +676,7 @@ class instance_ulduar : public InstanceMapScript
                             {
                                 if (GameObject* cache = instance->GetGameObject(thorim->AI()->GetData(DATA_THORIM_HARDMODE) ? CacheOfStormsHardmodeGUID : CacheOfStormsGUID))
                                 {
-                                    cache->SetLootRecipient(thorim->GetLootRecipient());
+                                    cache->SetLootRecipient(thorim);
                                     cache->SetRespawnTime(cache->GetRespawnDelay());
                                     cache->RemoveFlag(GO_FLAG_LOCKED | GO_FLAG_NOT_SELECTABLE | GO_FLAG_NODESPAWN);
                                 }


### PR DESCRIPTION
Ultranix's commit (at https://github.com/azerothcore/azerothcore-wotlk/commit/1b7d3708a6af5289071d5e1632853a409162f932 ) solves most of the issues by actually keeping track of the participants when a dungeon/raid boss is killed (or its loot cache is created) -- Master Looter list will only show the participants, and group loot only rolls for eligible participants.

You can still abuse this, however; If you enter the dungeon after a boss was killed and it was not looted at all, you cannot loot it either. However, as soon as someone tries to loot and and then cancels looting (releases the loot), you will be able to loot (similar to how group loot works). I solve this by checking the eligible participants when setting the lootable/interactible flags for creatures/objects.

Note: Ultranix's commit does not actually allow (in TC at least) a released player whose corpse is in a dungeon to be eligible for loot... since the ghost is outside, only the players inside the map are added in _allowedLooters. (could be changed though)

Only works for dungeon/raid bosses; Tested using various dungeon bosses for creature loot and using Valithria Dreamwalker's cache in ICC (stock TC wotlk...)

Epoch already implemented an InstanceBind for all players when a boss is killed in a raid. (Nitpick, since you don't really kill valithria doing her encounter + receiving her loot cache does not bind the players)