### PR TITLE
Rework attack power calculations to properly use positive and negative AP mods.

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -263,7 +263,8 @@ Creature::Creature(bool isWorldObject): Unit(isWorldObject), MapObject(), m_grou
     m_defaultMovementType(IDLE_MOTION_TYPE), m_spawnId(0), m_equipmentId(0), m_originalEquipmentId(0), m_AlreadyCallAssistance(false), m_AlreadySearchedAssistance(false), m_cannotReachTarget(false), m_cannotReachTimer(0),
     m_meleeDamageSchoolMask(SPELL_SCHOOL_MASK_NORMAL), m_originalEntry(0), m_homePosition(), m_transportHomePosition(), m_creatureInfo(nullptr), m_creatureData(nullptr), m_detectionDistance(20.0f), _waypointPathId(0),
     m_formation(nullptr), m_triggerJustAppeared(true), m_respawnCompatibilityMode(false), _lastDamagedTime(0),
-    _currentWaypointNodeInfo(0, 0), _regenerateHealth(true), _regenerateHealthLock(false), _isMissingCanSwimFlagOutOfCombat(false), m_assistanceTimer(0), m_forcePowerRegen(false)
+    _currentWaypointNodeInfo(0, 0), _regenerateHealth(true), _regenerateHealthLock(false), _isMissingCanSwimFlagOutOfCombat(false), m_assistanceTimer(0), m_forcePowerRegen(false),
+    m_BaseAttackPower(0), m_BaseRangedAttackPower(0)
 {
     m_valuesCount = UNIT_END;
 
@@ -1628,9 +1629,10 @@ void Creature::UpdateLevelDependantStats()
         , TSMutableNumber<uint32>(&attackPower)
         , TSMutableNumber<uint32>(&rangedAttackPower)
     );
-    SetStatFlatModifier(UNIT_MOD_ATTACK_POWER, BASE_VALUE, attackPower);
-    SetStatFlatModifier(UNIT_MOD_ATTACK_POWER_RANGED, BASE_VALUE, rangedAttackPower);
     // @tswow-end
+    // Save the variables to be called in UpdateAttackPowerAndDamage -- same as obsolete SetStatFlatModifier(UNIT_MOD_ATTACK_POWER)
+    m_BaseAttackPower = attackPower;
+    m_BaseRangedAttackPower = rangedAttackPower;
 
     float armor = (float)stats->GenerateArmor(cInfo); /// @todo Why is this treated as uint32 when it's a float?
     // @tswow-begin

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -503,8 +503,8 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         uint32 m_assistanceTimer;
 
         // set in Creature::UpdateLevelDependantStats, called in UpdateAttackPowerAndDamage
-        uint32 m_BaseAttackPower;
-        uint32 m_BaseRangedAttackPower;
+        uint16 m_BaseAttackPower;
+        uint16 m_BaseRangedAttackPower;
 };
 
 class TC_GAME_API AssistDelayEvent : public BasicEvent

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -501,6 +501,10 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         bool _isMissingCanSwimFlagOutOfCombat;
 
         uint32 m_assistanceTimer;
+
+        // set in Creature::UpdateLevelDependantStats, called in UpdateAttackPowerAndDamage
+        uint32 m_BaseAttackPower;
+        uint32 m_BaseRangedAttackPower;
 };
 
 class TC_GAME_API AssistDelayEvent : public BasicEvent

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7589,11 +7589,11 @@ void Player::_ApplyItemBonuses(ItemTemplate const* proto, uint8 slot, bool apply
                 ApplyRatingMod(CR_EXPERTISE, int32(val), apply);
                 break;
             case ITEM_MOD_ATTACK_POWER:
-                HandleStatFlatModifier(UNIT_MOD_ATTACK_POWER, TOTAL_VALUE, float(val), apply);
-                HandleStatFlatModifier(UNIT_MOD_ATTACK_POWER_RANGED, TOTAL_VALUE, float(val), apply);
+                HandleAttackPowerModifier(MELEE_AP_MODS, (val > 0) ? AP_MOD_POSITIVE_FLAT : AP_MOD_NEGATIVE_FLAT, float(val), apply);
+                HandleAttackPowerModifier(RANGED_AP_MODS, (val > 0) ? AP_MOD_POSITIVE_FLAT : AP_MOD_NEGATIVE_FLAT, float(val), apply);
                 break;
             case ITEM_MOD_RANGED_ATTACK_POWER:
-                HandleStatFlatModifier(UNIT_MOD_ATTACK_POWER_RANGED, TOTAL_VALUE, float(val), apply);
+                HandleAttackPowerModifier(RANGED_AP_MODS, (val > 0) ? AP_MOD_POSITIVE_FLAT : AP_MOD_NEGATIVE_FLAT, float(val), apply);
                 break;
 //            case ITEM_MOD_FERAL_ATTACK_POWER:
 //                ApplyFeralAPBonus(int32(val), apply);
@@ -14220,12 +14220,12 @@ void Player::ApplyEnchantment(Item* item, EnchantmentSlot slot, bool apply, bool
                             TC_LOG_DEBUG("entities.player.items", "+ {} EXPERTISE", enchant_amount);
                             break;
                         case ITEM_MOD_ATTACK_POWER:
-                            HandleStatFlatModifier(UNIT_MOD_ATTACK_POWER, TOTAL_VALUE, float(enchant_amount), apply);
-                            HandleStatFlatModifier(UNIT_MOD_ATTACK_POWER_RANGED, TOTAL_VALUE, float(enchant_amount), apply);
+                            HandleAttackPowerModifier(MELEE_AP_MODS, (enchant_amount > 0) ? AP_MOD_POSITIVE_FLAT : AP_MOD_NEGATIVE_FLAT, float(enchant_amount), apply);
+                            HandleAttackPowerModifier(RANGED_AP_MODS, (enchant_amount > 0) ? AP_MOD_POSITIVE_FLAT : AP_MOD_NEGATIVE_FLAT, float(enchant_amount), apply);
                             TC_LOG_DEBUG("entities.player.items", "+ {} ATTACK_POWER", enchant_amount);
                             break;
                         case ITEM_MOD_RANGED_ATTACK_POWER:
-                            HandleStatFlatModifier(UNIT_MOD_ATTACK_POWER_RANGED, TOTAL_VALUE, float(enchant_amount), apply);
+                            HandleAttackPowerModifier(RANGED_AP_MODS, (enchant_amount > 0) ? AP_MOD_POSITIVE_FLAT : AP_MOD_NEGATIVE_FLAT, float(enchant_amount), apply);
                             TC_LOG_DEBUG("entities.player.items", "+ {} RANGED_ATTACK_POWER", enchant_amount);
                             break;
 //                        case ITEM_MOD_FERAL_ATTACK_POWER:

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -585,7 +585,7 @@ void Player::UpdateAttackPowerAndDamage(bool ranged)
     float val2 = 0.0f;
     float level = float(GetLevel());
 
-    UnitMods unitMod = ranged ? UNIT_MOD_ATTACK_POWER_RANGED : UNIT_MOD_ATTACK_POWER;
+    AttackPowerModIndex unitMod = ranged ? RANGED_AP_MODS : MELEE_AP_MODS;
 
     if (ranged)
     {
@@ -703,11 +703,16 @@ void Player::UpdateAttackPowerAndDamage(bool ranged)
         );
     }
 
-    SetStatFlatModifier(unitMod, BASE_VALUE, val2);
 
-    float base_attPower  = GetFlatModifierValue(unitMod, BASE_VALUE) * GetPctModifierValue(unitMod, BASE_PCT);
-    float attPowerMod = GetFlatModifierValue(unitMod, TOTAL_VALUE);
+    float baseAttackPower  = val2;
+    // attack power mods are split into positive and negative field
+    float attackPowerModPositive = GetAttackPowerModifierValue(unitMod, AP_MOD_POSITIVE_FLAT);
+    float attackPowerModNegative = GetAttackPowerModifierValue(unitMod, AP_MOD_NEGATIVE_FLAT);
 
+    float attackPowerMultiplier = GetAttackPowerModifierValue(unitMod, AP_MOD_PCT) - 1.0f;
+
+    // Until we rip the bandaid and properly implement these auras, we just modify positive and negative mods accordingly
+    float temp_val = 0.0f;
     //add dynamic flat mods
     if (ranged)
     {
@@ -715,38 +720,48 @@ void Player::UpdateAttackPowerAndDamage(bool ranged)
         {
             AuraEffectList const& mRAPbyStat = GetAuraEffectsByType(SPELL_AURA_MOD_RANGED_ATTACK_POWER_OF_STAT_PERCENT);
             for (AuraEffect const* aurEff : mRAPbyStat)
-                attPowerMod += CalculatePct(GetStat(Stats(aurEff->GetMiscValue())), aurEff->GetAmount());
+            {
+                temp_val = CalculatePct(GetStat(Stats(aurEff->GetMiscValue())), aurEff->GetAmount());
+                if (temp_val > 0.0f)
+                    attackPowerModPositive += temp_val;
+                else
+                    attackPowerModNegative += temp_val;
+            }
         }
     }
     else
     {
         AuraEffectList const& mAPbyStat = GetAuraEffectsByType(SPELL_AURA_MOD_ATTACK_POWER_OF_STAT_PERCENT);
         for (AuraEffect const* aurEff : mAPbyStat)
-            attPowerMod += CalculatePct(GetStat(Stats(aurEff->GetMiscValue())), aurEff->GetAmount());
+        {
+            temp_val = CalculatePct(GetStat(Stats(aurEff->GetMiscValue())), aurEff->GetAmount());
+            if (temp_val > 0.0f)
+                attackPowerModPositive += temp_val;
+            else
+                attackPowerModNegative += temp_val;
+        }
     }
 
     // applies to both, amount updated in PeriodicTick each 30 seconds
-    attPowerMod += GetTotalAuraModifier(SPELL_AURA_MOD_ATTACK_POWER_OF_ARMOR);
-
-    float attPowerMultiplier = GetPctModifierValue(unitMod, TOTAL_PCT) - 1.0f;
+    temp_val =  GetTotalAuraModifier(SPELL_AURA_MOD_ATTACK_POWER_OF_ARMOR);
+    if (temp_val > 0.0f)
+        attackPowerModPositive += temp_val;
+    else
+        attackPowerModNegative += temp_val;
 
     if (ranged)
     {
-        SetRangedAttackPower(int32(base_attPower));
-        if (attPowerMod >= 0)
-            SetRangedAttackPowerModPos(int32(attPowerMod));
-        if (attPowerMod <= 0)
-            SetRangedAttackPowerModNeg(int32(attPowerMod));
-        SetRangedAttackPowerMultiplier(attPowerMultiplier);
+        SetRangedAttackPower(int32(baseAttackPower));
+        SetRangedAttackPowerModPos(int32(attackPowerModPositive));
+        SetRangedAttackPowerModNeg(int32(attackPowerModNegative));
+        SetRangedAttackPowerMultiplier(attackPowerMultiplier);
     }
     else
     {
-        SetAttackPower(int32(base_attPower));
-        if (attPowerMod >= 0)
-            SetAttackPowerModPos(int32(attPowerMod));
-        if (attPowerMod <= 0)
-            SetAttackPowerModNeg(int32(attPowerMod));
-        SetAttackPowerMultiplier(attPowerMultiplier);
+        SetAttackPower(int32(baseAttackPower));
+        SetAttackPowerModPos(int32(attackPowerModPositive));
+        SetAttackPowerModNeg(int32(attackPowerModNegative));
+        SetAttackPowerMultiplier(attackPowerMultiplier);
     }
 
     Pet* pet = GetPet();                                //update pet's AP
@@ -1470,41 +1485,40 @@ void Creature::UpdateMaxPower(Powers power)
 
 void Creature::UpdateAttackPowerAndDamage(bool ranged)
 {
-    UnitMods unitMod = ranged ? UNIT_MOD_ATTACK_POWER_RANGED : UNIT_MOD_ATTACK_POWER;
+    AttackPowerModIndex unitMod = ranged ? RANGED_AP_MODS : MELEE_AP_MODS;
 
-    float baseAttackPower       = GetFlatModifierValue(unitMod, BASE_VALUE) * GetPctModifierValue(unitMod, BASE_PCT);
-    float attackPowerMod        = GetFlatModifierValue(unitMod, TOTAL_VALUE);
-    float attackPowerMultiplier = GetPctModifierValue(unitMod, TOTAL_PCT) - 1.0f;
+    float baseAttackPower = ranged ? m_BaseRangedAttackPower : m_BaseAttackPower;
 
+    float attackPowerModPositive = GetAttackPowerModifierValue(unitMod, AP_MOD_POSITIVE_FLAT);
+    float attackPowerModNegative = GetAttackPowerModifierValue(unitMod, AP_MOD_NEGATIVE_FLAT);
+    float attackPowerMultiplier = GetAttackPowerModifierValue(unitMod, AP_MOD_PCT) - 1.0f;
+
+    // Commenting out until hook is changed to accept both AP Mods
     // @tswow-begin
-    FIRE_ID(
-        GetCreatureTemplate()->events.id
-        , Creature,OnUpdateAttackPowerDamage
-        , TSCreature(this)
-        , TSMutableNumber<float>(&baseAttackPower)
-        , TSMutableNumber<float>(&attackPowerMod)
-        , TSMutableNumber<float>(&attackPowerMultiplier)
-        , false
-        , ranged
-    );
+    // FIRE_ID(
+    //     GetCreatureTemplate()->events.id
+    //     , Creature,OnUpdateAttackPowerDamage
+    //     , TSCreature(this)
+    //     , TSMutableNumber<float>(&baseAttackPower)
+    //     , TSMutableNumber<float>(&attackPowerMod)
+    //     , TSMutableNumber<float>(&attackPowerMultiplier)
+    //     , false
+    //     , ranged
+    // );
     // @tswow-end
 
     if (ranged)
     {
         SetRangedAttackPower(int32(baseAttackPower));
-        if (attackPowerMod >= 0)
-            SetRangedAttackPowerModPos(int32(attackPowerMod));
-        if (attackPowerMod <= 0)
-            SetRangedAttackPowerModNeg(int32(attackPowerMod));
+        SetRangedAttackPowerModPos(int32(attackPowerModPositive));
+        SetRangedAttackPowerModNeg(int32(attackPowerModNegative));
         SetRangedAttackPowerMultiplier(attackPowerMultiplier);
     }
     else
     {
         SetAttackPower(int32(baseAttackPower));
-        if (attackPowerMod >= 0)
-            SetAttackPowerModPos(int32(attackPowerMod));
-        if (attackPowerMod <= 0)
-            SetAttackPowerModNeg(int32(attackPowerMod));
+        SetAttackPowerModPos(int32(attackPowerModPositive));
+        SetAttackPowerModNeg(int32(attackPowerModNegative));
         SetAttackPowerMultiplier(attackPowerMultiplier);
     }
 
@@ -1890,7 +1904,7 @@ void Guardian::UpdateAttackPowerAndDamage(bool ranged)
 
     float val = 0.0f;
     float bonusAP = 0.0f;
-    UnitMods unitMod = UNIT_MOD_ATTACK_POWER;
+    AttackPowerModIndex unitMod = MELEE_AP_MODS;
 
     if (GetEntry() == ENTRY_IMP)                                   // imp's attack power
         val = GetStat(STAT_STRENGTH) - 10.0f;
@@ -1960,29 +1974,33 @@ void Guardian::UpdateAttackPowerAndDamage(bool ranged)
         }
     }
 
-    SetStatFlatModifier(UNIT_MOD_ATTACK_POWER, BASE_VALUE, val + bonusAP);
-
     //in BASE_VALUE of UNIT_MOD_ATTACK_POWER for creatures we store data of meleeattackpower field in DB
-    float base_attPower  = GetFlatModifierValue(unitMod, BASE_VALUE) * GetPctModifierValue(unitMod, BASE_PCT);
-    float attPowerMod = GetFlatModifierValue(unitMod, TOTAL_VALUE);
-    float attPowerMultiplier = GetPctModifierValue(unitMod, TOTAL_PCT) - 1.0f;
+    float baseAttackPower  = val + bonusAP;
 
+    // attack power mods are split into positive and negative field
+    float attackPowerModPositive = GetAttackPowerModifierValue(unitMod, AP_MOD_POSITIVE_FLAT);
+    float attackPowerModNegative = GetAttackPowerModifierValue(unitMod, AP_MOD_NEGATIVE_FLAT);
+
+    float attackPowerMultiplier = GetAttackPowerModifierValue(unitMod, AP_MOD_PCT) - 1.0f;
+
+    // Commenting out until hook is changed to accept both AP Mods
     // @tswow-begin
-    FIRE_ID(
-        GetCreatureTemplate()->events.id
-        , Creature,OnUpdateAttackPowerDamage
-        , TSCreature(this)
-        , TSMutableNumber<float>(&base_attPower)
-        , TSMutableNumber<float>(&attPowerMod)
-        , TSMutableNumber<float>(&attPowerMultiplier)
-        , true
-        , ranged
-    );
+    // FIRE_ID(
+    //     GetCreatureTemplate()->events.id
+    //     , Creature,OnUpdateAttackPowerDamage
+    //     , TSCreature(this)
+    //     , TSMutableNumber<float>(&baseAttackPower)
+    //     , TSMutableNumber<float>(&attPowerMod)
+    //     , TSMutableNumber<float>(&attackPowerMultiplier)
+    //     , true
+    //     , ranged
+    // );
     // @tswow-end
 
-    SetAttackPower(int32(base_attPower));
-    SetAttackPowerModPos(int32(attPowerMod));
-    SetAttackPowerMultiplier(attPowerMultiplier);
+    SetAttackPower(int32(baseAttackPower));
+    SetAttackPowerModPos(int32(attackPowerModPositive));
+    SetAttackPowerModNeg(int32(attackPowerModNegative));
+    SetAttackPowerMultiplier(attackPowerMultiplier);
 
     //automatically update weapon damage after attack power modification
     UpdateDamagePhysical(BASE_ATTACK);

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -174,8 +174,6 @@ enum UnitMods
     UNIT_MOD_RESISTANCE_FROST,
     UNIT_MOD_RESISTANCE_SHADOW,
     UNIT_MOD_RESISTANCE_ARCANE,
-    UNIT_MOD_ATTACK_POWER,
-    UNIT_MOD_ATTACK_POWER_RANGED,
     UNIT_MOD_DAMAGE_MAINHAND,
     UNIT_MOD_DAMAGE_OFFHAND,
     UNIT_MOD_DAMAGE_RANGED,
@@ -598,6 +596,26 @@ struct SpellPeriodicAuraLogInfo
     uint32 resist;
     float  multiplier;
     bool   critical;
+};
+
+struct AttackPowerModInfo
+{
+    float positiveMods = 0; // int16 in client
+    float negativeMods = 0; // int16 in client
+    float multiplier = 1.0f;
+};
+enum AttackPowerModType
+{
+    AP_MOD_POSITIVE_FLAT,
+    AP_MOD_NEGATIVE_FLAT,
+    AP_MOD_PCT,
+    AP_MOD_TYPE_COUNT,
+};
+enum AttackPowerModIndex
+{
+    MELEE_AP_MODS,
+    RANGED_AP_MODS,
+    AP_MODS_COUNT,
 };
 
 uint32 createProcHitMask(SpellNonMeleeDamage* damageInfo, SpellMissInfo missCondition);
@@ -1531,6 +1549,9 @@ class TC_GAME_API Unit : public WorldObject
         float GetFlatModifierValue(UnitMods unitMod, UnitModifierFlatType modifierType) const;
         float GetPctModifierValue(UnitMods unitMod, UnitModifierPctType modifierType) const;
 
+        bool HandleAttackPowerModifier(AttackPowerModIndex index, AttackPowerModType modifierType, float amount, bool apply);
+        float GetAttackPowerModifierValue(AttackPowerModIndex index, AttackPowerModType modifierType) const;
+
         void UpdateUnitMod(UnitMods unitMod);
 
         // only players have item requirements
@@ -1902,6 +1923,7 @@ class TC_GAME_API Unit : public WorldObject
 
         float m_auraFlatModifiersGroup[UNIT_MOD_END][MODIFIER_TYPE_FLAT_END];
         float m_auraPctModifiersGroup[UNIT_MOD_END][MODIFIER_TYPE_PCT_END];
+        AttackPowerModInfo m_attackPowerMods[AP_MODS_COUNT]; // Handle both flat + pct
         float m_weaponDamage[MAX_ATTACK][2][2];
         bool m_canModifyStats;
 

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -4165,7 +4165,7 @@ void AuraEffect::HandleAuraModAttackPower(AuraApplication const* aurApp, uint8 m
 
     Unit* target = aurApp->GetTarget();
 
-    target->HandleStatFlatModifier(UNIT_MOD_ATTACK_POWER, TOTAL_VALUE, float(GetAmount()), apply);
+    target->HandleAttackPowerModifier(MELEE_AP_MODS, GetSpellInfo()->IsPositive() ? AP_MOD_POSITIVE_FLAT : AP_MOD_NEGATIVE_FLAT, float(GetAmount()), apply);
 }
 
 void AuraEffect::HandleAuraModRangedAttackPower(AuraApplication const* aurApp, uint8 mode, bool apply) const
@@ -4178,7 +4178,7 @@ void AuraEffect::HandleAuraModRangedAttackPower(AuraApplication const* aurApp, u
     if ((target->GetClassMask() & CLASSMASK_WAND_USERS) != 0)
         return;
 
-    target->HandleStatFlatModifier(UNIT_MOD_ATTACK_POWER_RANGED, TOTAL_VALUE, float(GetAmount()), apply);
+    target->HandleAttackPowerModifier(RANGED_AP_MODS, GetSpellInfo()->IsPositive() ? AP_MOD_POSITIVE_FLAT : AP_MOD_NEGATIVE_FLAT, float(GetAmount()), apply);
 }
 
 void AuraEffect::HandleAuraModAttackPowerPercent(AuraApplication const* aurApp, uint8 mode, bool apply) const
@@ -4188,14 +4188,9 @@ void AuraEffect::HandleAuraModAttackPowerPercent(AuraApplication const* aurApp, 
 
     Unit* target = aurApp->GetTarget();
 
-    //UNIT_FIELD_ATTACK_POWER_MULTIPLIER = multiplier - 1
-    if (apply)
-        target->ApplyStatPctModifier(UNIT_MOD_ATTACK_POWER, TOTAL_PCT, float(GetAmount()));
-    else
-    {
-        float amount = target->GetTotalAuraMultiplier(SPELL_AURA_MOD_ATTACK_POWER_PCT);
-        target->SetStatPctModifier(UNIT_MOD_ATTACK_POWER, TOTAL_PCT, amount);
-    }
+    // GetAmount is 10 for 10% AP increase
+    // target->GetTotalAuraMultiplier(SPELL_AURA_MOD_ATTACK_POWER_PCT) is 1.1 for 10% AP increase
+    target->HandleAttackPowerModifier(MELEE_AP_MODS, AP_MOD_PCT, float(GetAmount()), apply);
 }
 
 void AuraEffect::HandleAuraModRangedAttackPowerPercent(AuraApplication const* aurApp, uint8 mode, bool apply) const
@@ -4209,13 +4204,7 @@ void AuraEffect::HandleAuraModRangedAttackPowerPercent(AuraApplication const* au
         return;
 
     //UNIT_FIELD_RANGED_ATTACK_POWER_MULTIPLIER = multiplier - 1
-    if (apply)
-        target->ApplyStatPctModifier(UNIT_MOD_ATTACK_POWER_RANGED, TOTAL_PCT, float(GetAmount()));
-    else
-    {
-        float amount = target->GetTotalAuraMultiplier(SPELL_AURA_MOD_RANGED_ATTACK_POWER_PCT);
-        target->SetStatPctModifier(UNIT_MOD_ATTACK_POWER_RANGED, TOTAL_PCT, amount);
-    }
+    target->HandleAttackPowerModifier(RANGED_AP_MODS, AP_MOD_PCT, float(GetAmount()), apply);
 }
 
 void AuraEffect::HandleAuraModRangedAttackPowerOfStatPercent(AuraApplication const* aurApp, uint8 mode, bool /*apply*/) const

--- a/src/server/scripts/Spells/spell_pet.cpp
+++ b/src/server/scripts/Spells/spell_pet.cpp
@@ -320,8 +320,9 @@ public:
                     {
                         if (AuraEffect* /* aurEff */ect = owner->GetAuraEffect(56246, EFFECT_0))
                         {
-                            float base_attPower = pet->GetFlatModifierValue(UNIT_MOD_ATTACK_POWER, BASE_VALUE) * pet->GetPctModifierValue(UNIT_MOD_ATTACK_POWER, BASE_PCT);
-                            amount += CalculatePct(amount+base_attPower, /* aurEff */ect->GetAmount());
+                            // comment so we don't bother updating calculations after porting vmangos AP calcs
+                            //float base_attPower = pet->GetFlatModifierValue(UNIT_MOD_ATTACK_POWER, BASE_VALUE) * pet->GetPctModifierValue(UNIT_MOD_ATTACK_POWER, BASE_PCT);
+                            //amount += CalculatePct(amount+base_attPower, /* aurEff */ect->GetAmount());
                         }
                     }
                 }


### PR DESCRIPTION
Based on vmangos commit at https://github.com/vmangos/core/commit/2646715596d24ba205b03a7f3e1cee1c4ffa4ab9

There are two AP modifiers that the client expects, a positive one and a negative one. TC was not handling them separately in some cases (in attPowerMod), which led to bugs during applications and deapplications of AP auras.

Most of the magic is inside UpdateAttackPowerAndDamage, the AP modifiers (+, - and multiplier) are kept inside m_attackPowerMods (which replace the AP m_auraFlatModifiersGroup + pct), which is being updated via AuraEffects.

Store the base AP of creatures so that we do not fetch them on every UpdateAttackAndPower.

Tested using a variety of +/- AP auras, +/- %AP auras on player/pet/creatures... and I was not able to break it.
Should solve issues like https://github.com/Project-Epoch/bugtracker/issues/8338
