### PR TITLE
Various hunter trap fixes.

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1820,8 +1820,14 @@ bool WorldObject::CanDetectStealthOf(WorldObject const* obj, bool checkAlert) co
         // Detection is level * 5 plus any modifiers
         int32 detectSkill = int32(GetLevelForTarget(obj)) * 5 + m_stealthDetect.GetValue(StealthType(i));
         if (go)
-            if (Unit* owner = go->GetOwner())
-                detectSkill -= int32(owner->GetLevelForTarget(this)) * 5;
+        {
+            // commenting out, obj->GetLevelForTarget(this) in stealthSkill already checks GetOwner() and returns owner level
+            // However, use the m_stealth value for traps (70 by default)
+            // if (Unit* owner = go->GetOwner())
+            //     detectSkill -= int32(owner->GetLevelForTarget(this)) * 5;
+            // Could potentially add a check here for STEALTH_TRAP only? seems only m_stealth.AddValue for traps anyway
+            detectSkill -= int32(obj->m_stealth.GetValue(StealthType(i)));
+        }
 
         // Calculate max distance
         visibilityRange += (detectSkill - stealthSkill) * yardsPerLevel / 5.0f;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2403,7 +2403,8 @@ void Spell::TargetInfo::PreprocessTarget(Spell* spell)
     else if (MissCondition == SPELL_MISS_REFLECT && ReflectResult == SPELL_MISS_NONE)
         _spellHitTarget = spell->m_caster->ToUnit();
 
-    if (spell->m_originalCaster && MissCondition != SPELL_MISS_EVADE && !spell->m_originalCaster->IsFriendlyTo(unit) && (!spell->m_spellInfo->IsPositive() || spell->m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (spell->m_spellInfo->HasInitialAggro() || unit->IsEngaged()))
+    if (spell->m_originalCaster && MissCondition != SPELL_MISS_EVADE && !spell->m_originalCaster->IsFriendlyTo(unit) && (!spell->m_spellInfo->IsPositive() || spell->m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (spell->m_spellInfo->HasInitialAggro() || unit->IsEngaged()) &&
+        !(spell->m_caster->IsGameObject() && unit->IsPlayer())) // hunter traps should not put you in combat
         unit->SetInCombatWith(spell->m_originalCaster);
 
     spell->CallScriptBeforeHitHandlers(MissCondition);
@@ -7854,7 +7855,8 @@ void Spell::PreprocessSpellLaunch(TargetInfo& targetInfo)
         return;
 
     // This will only cause combat - the target will engage once the projectile hits (in Spell::TargetInfo::PreprocessTarget)
-    if (m_originalCaster && targetInfo.MissCondition != SPELL_MISS_EVADE && !m_originalCaster->IsFriendlyTo(targetUnit) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (m_spellInfo->HasInitialAggro() || targetUnit->IsEngaged()))
+    if (m_originalCaster && targetInfo.MissCondition != SPELL_MISS_EVADE && !m_originalCaster->IsFriendlyTo(targetUnit) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (m_spellInfo->HasInitialAggro() || targetUnit->IsEngaged()) &&
+        !(m_caster->IsGameObject() && targetUnit->IsPlayer())) // hunter traps should not put you in combat
         m_originalCaster->SetInCombatWith(targetUnit, true);
 
     Unit* unit = nullptr;


### PR DESCRIPTION
1. Stop hunter traps from starting combat when they are procced by other players (creatures still start combat).
Verified via immolation trap on classic.
based on https://github.com/vmangos/core/commit/176847a7376687f1620e1876330b57f446354dd8

2. Gameobjects stealth calculation was bugged, using twice the level of the trap (which is the same level as the hunter), and not using the m_stealth value provided by the core. After the fix, rogues should be able to see traps, whereas for other classes traps are still invisible (unless they overlevel the hunter).