### PR TITLE
Allow pets to attack targets with breakable CC if commanded.

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -68,14 +68,6 @@ void PetAI::UpdateAI(uint32 diff)
 
     if (me->GetVictim() && me->EnsureVictim()->IsAlive())
     {
-        // is only necessary to stop casting, the pet must not exit combat
-        if (!me->GetCurrentSpell(CURRENT_CHANNELED_SPELL) && // ignore channeled spells (Pin, Seduction)
-            me->EnsureVictim()->HasBreakableByDamageCrowdControlAura(me))
-        {
-            me->InterruptNonMeleeSpells(false);
-            return;
-        }
-
         if (NeedToStop())
         {
             TC_LOG_TRACE("scripts.ai.petai", "PetAI::UpdateAI: AI stopped attacking {}", me->GetGUID().ToString());

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2712,6 +2712,20 @@ void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
             }
         }
 
+        // Do it after we apply effects, otherwise HasBreakableByDamageCrowdControlAura returns false
+        if ((spell->m_spellInfo->AuraInterruptFlags & AURA_INTERRUPT_FLAG_TAKE_DAMAGE) &&
+            _spellHitTarget->HasBreakableByDamageCrowdControlAura(spell->m_caster->ToUnit()))
+        {
+            // Tell any pets to stop attacking the target on application of breakable crowd control spells
+            // For QoL, do the same for Guardians -- shadowfiend / druid treants etc.
+            Unit::AttackerSet attackers = _spellHitTarget->getAttackers();
+            for (const auto attacker : attackers)
+            {
+                if (attacker->IsPet() || attacker->IsGuardian())
+                    attacker->AttackStop();
+            }
+        }
+
         // Needs to be called after dealing damage/healing to not remove breaking on damage auras
         spell->DoTriggersOnSpellHit(_spellHitTarget, EffectMask);
 


### PR DESCRIPTION
Remove the check in PetAI::UpdateAI since it stops us from attacking CC'd targets altogether.

Replace with a better fix by broadcasting once to pets (and guardians for QoL?) when a CC aura is applied on the target and telling them to stop attacking. -- fix taken from vmangos