### PR TITLE
Modify aggro detection range for entities controlled by the player.

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2104,18 +2104,27 @@ bool Creature::CheckNoGrayAggroConfig(Player* player, uint32 playerLevel, uint32
     return false;
 }
 
-float Creature::GetAttackDistance(Unit const* player) const
+float Creature::GetAttackDistance(Unit const* target) const
 {
     float aggroRate = sWorld->getRate(RATE_CREATURE_AGGRO);
     if (aggroRate == 0)
         return 0.0f;
 
+    // proximity aggro does not target disabled pets (owner is mounted)
+    if (target->IsPet() || target->IsGuardian())
+        if (target->HasUnitFlag(UNIT_FLAG_STUNNED) && !target->HasUnitState(UNIT_STATE_STUNNED)) // HACK, found in Unit::Mount and Unit::Dismount
+            return 0.0f;
+
     // WoW Wiki: the minimum radius seems to be 5 yards, while the maximum range is 45 yards
     float maxRadius = (45.0f * sWorld->getRate(RATE_CREATURE_AGGRO));
     float minRadius = (5.0f * sWorld->getRate(RATE_CREATURE_AGGRO));
 
+    // pets and charmed mobs use owner level
+    Player* player = target->GetCharmerOrOwnerPlayerOrPlayerItself();
+    uint32 const targetLevel = player ? player->GetLevel() : target->GetLevel();
+
     uint8 expansionMaxLevel = uint8(GetMaxLevelForExpansion(GetCreatureTemplate()->expansion));
-    int32 levelDifference = GetLevel() - player->GetLevel();
+    int32 levelDifference = GetLevel() - targetLevel;
 
     // The aggro radius for creatures with equal level as the player is 20 yards.
     // The combatreach should not get taken into account for the distance so we drop it from the range (see Supremus as expample)
@@ -2135,7 +2144,7 @@ float Creature::GetAttackDistance(Unit const* player) const
     // This makes sure that creatures such as bosses wont have a bigger aggro range than the rest of the npc's
     // The following code is used for blizzlike behaivior such as skippable bosses
     if (GetLevel() > expansionMaxLevel)
-        aggroRadius = baseAggroDistance + float(expansionMaxLevel - player->GetLevel());
+        aggroRadius = baseAggroDistance + float(expansionMaxLevel - targetLevel);
 
     // Make sure that we wont go over the total range limits
     if (aggroRadius > maxRadius)

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -250,7 +250,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         uint32 m_spells[MAX_CREATURE_SPELLS];
 
         bool CanStartAttack(Unit const* u, bool force) const;
-        float GetAttackDistance(Unit const* player) const;
+        float GetAttackDistance(Unit const* target) const;
         float GetDetectionRange() const { return m_detectionDistance; }
 
         float GetAggroRange(Unit const* target) const;


### PR DESCRIPTION
Use the player level for pets (guardians included) and charmed units in aggro range calculations.

HACK: Reduce aggro range for pets and guardians while the player is mounted. Enemies which are attacking the pet still continue to do so.

Code taken from vmangos GetAttackDistance implementation.
