### PR TITLE
Solve imp cast range and wonky movement.

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -440,7 +440,10 @@ void PetAI::DoAttack(Unit* target, bool chase)
             float chaseDistance = m_bMeleeAttack ? 0.f : me->GetPetChaseDistance();
             float angle = chaseDistance == 0.f && target->GetTypeId() != TYPEID_PLAYER && !target->IsPet() ? float(M_PI) : 0.f;
             float tolerance = chaseDistance == 0.f ? float(M_PI_4) : float(M_PI * 2);
-            me->GetMotionMaster()->MoveChase(target, ChaseRange(0.f, chaseDistance), ChaseAngle(angle, tolerance));
+            if (m_bMeleeAttack) // Pass angle and tolerance only for melee chasing, otherwise imp bugs out.
+                me->GetMotionMaster()->MoveChase(target, ChaseRange(0.f, chaseDistance), ChaseAngle(angle, tolerance));
+            else
+                me->GetMotionMaster()->MoveChase(target, ChaseRange(0.f, chaseDistance));
         }
         else // (Stay && ((Aggressive || Defensive) && In Melee Range)))
         {

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3098,7 +3098,7 @@ float Creature::GetPetChaseDistance() const
 
     /** @epoch-start */
     if (GetEntry() == 416 || GetEntry() == 510 || GetEntry() == 37994) // Imp / Water Ele
-        range = 20.0f;
+        range = std::max(20.0f, range);
     /** @epoch-end */
 
     return range;


### PR DESCRIPTION
Use the higher number between default chase distance and autocast spell range.

Do not pass a ChaseAngle at all (instead of 0 angle, 2* Pi tolerance) so that the imp will path straight towards the target.