### PR TITLE
Rename `SPELL_ATTR2_HEALTH_FUNNEL` to `SPELL_ATTR2_NO_TARGET_PER_SECOND_COSTS` and correct implementation of it

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5423,10 +5423,6 @@ void AuraEffect::HandlePeriodicHealAurasTick(Unit* target, Unit* caster) const
         return;
     }
 
-    // heal for caster damage (must be alive)
-    if (target != caster && GetSpellInfo()->HasAttribute(SPELL_ATTR2_HEALTH_FUNNEL) && (!caster || !caster->IsAlive()))
-        return;
-
     // don't regen when permanent aura target has full power
     if (GetBase()->IsPermanent() && target->IsFullHealth())
         return;
@@ -5485,25 +5481,6 @@ void AuraEffect::HandlePeriodicHealAurasTick(Unit* target, Unit* caster) const
         target->GetThreatManager().ForwardThreatForAssistingMe(caster, healInfo.GetEffectiveHeal() * 0.5f, GetSpellInfo());
 
     bool haveCastItem = !GetBase()->GetCastItemGUID().IsEmpty();
-
-    // Health Funnel
-    // damage caster for heal amount
-    if (target != caster && GetSpellInfo()->HasAttribute(SPELL_ATTR2_HEALTH_FUNNEL))
-    {
-        uint32 funnelDamage = GetSpellInfo()->ManaPerSecond; // damage is not affected by spell power
-
-        if (funnelDamage > healInfo.GetEffectiveHeal() && healInfo.GetEffectiveHeal())
-            funnelDamage = healInfo.GetEffectiveHeal();
-
-        uint32 funnelAbsorb = 0;
-        Unit::DealDamageMods(caster, funnelDamage, &funnelAbsorb);
-
-        if (caster)
-            caster->SendSpellNonMeleeDamageLog(caster, GetId(), funnelDamage, GetSpellInfo()->GetSchoolMask(), funnelAbsorb, 0, true, 0, false);
-
-        CleanDamage cleanDamage = CleanDamage(0, 0, BASE_ATTACK, MELEE_HIT_NORMAL);
-        Unit::DealDamage(caster, caster, funnelDamage, &cleanDamage, SELF_DAMAGE, GetSpellInfo()->GetSchoolMask(), GetSpellInfo(), true);
-    }
 
     // %-based heal - does not proc auras
     if (GetAuraType() == SPELL_AURA_OBS_MOD_HEALTH)

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -837,7 +837,8 @@ void Aura::Update(uint32 diff, Unit* caster)
                 m_timeCla -= diff;
             else if (caster)
             {
-                if (int32 manaPerSecond = m_spellInfo->ManaPerSecond + m_spellInfo->ManaPerSecondPerLevel * caster->GetLevel())
+                int32 manaPerSecond = m_spellInfo->ManaPerSecond + m_spellInfo->ManaPerSecondPerLevel * caster->GetLevel();
+                if (manaPerSecond && (!GetSpellInfo()->HasAttribute(SPELL_ATTR2_NO_TARGET_PER_SECOND_COSTS) || GetCasterGUID() == this->GetOwner()->GetGUID()))
                 {
                     m_timeCla += 1000 - diff;
 

--- a/src/server/shared/SharedDefines.h
+++ b/src/server/shared/SharedDefines.h
@@ -482,7 +482,7 @@ enum SpellAttr2 : uint32
     SPELL_ATTR2_UNK8                             = 0x00000100, // TITLE Unknown attribute 8@Attr2
     SPELL_ATTR2_UNK9                             = 0x00000200, // TITLE Unknown attribute 9@Attr2
     SPELL_ATTR2_UNK10                            = 0x00000400, // TITLE Unknown attribute 10@Attr2 DESCRIPTION Related to taming?
-    SPELL_ATTR2_HEALTH_FUNNEL                    = 0x00000800, // TITLE Health Funnel
+    SPELL_ATTR2_NO_TARGET_PER_SECOND_COSTS       = 0x00000800, // TITLE No Target Per-Second Costs
     SPELL_ATTR2_UNK12                            = 0x00001000, // TITLE Unknown attribute 12@Attr2
     SPELL_ATTR2_PRESERVE_ENCHANT_IN_ARENA        = 0x00002000, // TITLE Enchant persists when entering arena
     SPELL_ATTR2_UNK14                            = 0x00004000, // TITLE Unknown attribute 14@Attr2

--- a/src/server/shared/enuminfo_SharedDefines.cpp
+++ b/src/server/shared/enuminfo_SharedDefines.cpp
@@ -537,7 +537,7 @@ TC_API_EXPORT EnumText EnumUtils<SpellAttr2>::ToString(SpellAttr2 value)
         case SPELL_ATTR2_UNK8: return { "SPELL_ATTR2_UNK8", "Unknown attribute 8@Attr2", "" };
         case SPELL_ATTR2_UNK9: return { "SPELL_ATTR2_UNK9", "Unknown attribute 9@Attr2", "" };
         case SPELL_ATTR2_UNK10: return { "SPELL_ATTR2_UNK10", "Unknown attribute 10@Attr2", "Related to taming?" };
-        case SPELL_ATTR2_HEALTH_FUNNEL: return { "SPELL_ATTR2_HEALTH_FUNNEL", "Health Funnel", "" };
+        case SPELL_ATTR2_NO_TARGET_PER_SECOND_COSTS: return { "SPELL_ATTR2_NO_TARGET_PER_SECOND_COSTS", "No Target Per-Second Costs", "" };
         case SPELL_ATTR2_UNK12: return { "SPELL_ATTR2_UNK12", "Unknown attribute 12@Attr2", "" };
         case SPELL_ATTR2_PRESERVE_ENCHANT_IN_ARENA: return { "SPELL_ATTR2_PRESERVE_ENCHANT_IN_ARENA", "Enchant persists when entering arena", "" };
         case SPELL_ATTR2_UNK14: return { "SPELL_ATTR2_UNK14", "Unknown attribute 14@Attr2", "" };
@@ -581,7 +581,7 @@ TC_API_EXPORT SpellAttr2 EnumUtils<SpellAttr2>::FromIndex(size_t index)
         case 8: return SPELL_ATTR2_UNK8;
         case 9: return SPELL_ATTR2_UNK9;
         case 10: return SPELL_ATTR2_UNK10;
-        case 11: return SPELL_ATTR2_HEALTH_FUNNEL;
+        case 11: return SPELL_ATTR2_NO_TARGET_PER_SECOND_COSTS;
         case 12: return SPELL_ATTR2_UNK12;
         case 13: return SPELL_ATTR2_PRESERVE_ENCHANT_IN_ARENA;
         case 14: return SPELL_ATTR2_UNK14;
@@ -622,7 +622,7 @@ TC_API_EXPORT size_t EnumUtils<SpellAttr2>::ToIndex(SpellAttr2 value)
         case SPELL_ATTR2_UNK8: return 8;
         case SPELL_ATTR2_UNK9: return 9;
         case SPELL_ATTR2_UNK10: return 10;
-        case SPELL_ATTR2_HEALTH_FUNNEL: return 11;
+        case SPELL_ATTR2_NO_TARGET_PER_SECOND_COSTS: return 11;
         case SPELL_ATTR2_UNK12: return 12;
         case SPELL_ATTR2_PRESERVE_ENCHANT_IN_ARENA: return 13;
         case SPELL_ATTR2_UNK14: return 14;


### PR DESCRIPTION
Renamed Spell Attributes2 Health Funnel to No Target Per Second Costs, based on the TBCC attribute names leak.

Removed Health Funnel's incorrect implementation, which isn't accurate for 3.3.5 or 2.4.3 or 1.12. Health Funnel should only consume as much health as it displays on the tooltip, your pet is healed for more than the amount of damage dealt to you.

Now instead the newly renamed attribute is called during the Per Second Cost code to prevent a spell from being priced for every target affected by it. Health Funnel affects both the target and the caster, which caused it to get priced at double the intended amount.

In the case of custom content on custom servers this fixes an issue where similar effects (such as attaching a per-second cost to Drain Soul) would consume mana based on the amount of targets affected.

Implementation inspiration comes from https://github.com/vmangos/core/commit/9d1545f0a78ea314b120991ec626c8af67ce3008 (control-F "NO_TARGET_PER_SECOND_COSTS")
