### PR TITLE
Improvements to health regen.

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2046,7 +2046,7 @@ bool Player::IsImmunedToSpellEffect(SpellInfo const* spellInfo, SpellEffectInfo 
 
 void Player::HandleFoodEmotes(uint32 diff)
 {
-    m_foodEmoteTimerCount += m_regenTimer;
+    m_foodEmoteTimerCount += diff;
 
     // Handles the emotes for drinking and eating.
     // According to sniffs there is a background timer going on that repeats independed from the time window where the aura applies.

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -225,6 +225,7 @@ Player::Player(WorldSession* session): Unit(true)
 
     m_regenTimer = 0;
     m_foodEmoteTimerCount = 0;
+    m_carryHealthRegen = 0;
     m_weaponChangeTimer = 0;
 
     m_zoneUpdateId = uint32(-1);
@@ -2228,10 +2229,16 @@ void Player::RegenerateHealth(uint32 diff)
     // always regeneration bonus (including combat)
     addValue += (GetTotalAuraModifier(SPELL_AURA_MOD_HEALTH_REGEN_IN_COMBAT) / 5.0f);
 
+    addValue *= float(diff) / 1000;
+
+    // Health fractions get carried to the next tick
+    addValue += m_carryHealthRegen;
+    m_carryHealthRegen = addValue - int32(addValue);
+
     if (addValue < 0.0f)
         addValue = 0.0f;
 
-    ModifyHealth(int32(addValue * float(diff) / 1000));
+    ModifyHealth(int32(addValue));
 }
 
 void Player::ResetAllPowers()

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2313,6 +2313,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         // Gamemaster whisper whitelist
         GuidList WhisperList;
         uint32 m_foodEmoteTimerCount;
+        float m_carryHealthRegen;
         float m_powerFraction[MAX_POWERS];
         uint32 m_contestedPvPTimer;
 


### PR DESCRIPTION
Allow hp regen calculations to use a carry; mainly helps for hp5 potions --> a 6hp5 potion would only give 2 hp every 2 seconds, effectively being nerfed.
Based on https://github.com/vmangos/core/commit/1a9b78faf6aec131f2ef5c52dc9950439d388a6c

Fix the permanent sound/emote looping while eating and drinking

Small nitpick: We are calling RegenerateAll() whenever m_regenTimer exceeds 2000 ms, but we are not calling it with 2000 ms but with the actual m_regenTimer which has small overflow, so each tick calculation is not for a true 2000 ms tick. If the diff is small it wouldn't matter but it's just a nitpick in how the code is written