### PR TITLE
Fix SPELL_ATTR1_DISMISS_PET regression caused by https://github.com/P…

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3516,9 +3516,15 @@ void Spell::_cast(bool skipCheck)
     }
 
     if (Unit* unitCaster = m_caster->ToUnit())
+    {
         if (m_spellInfo->HasAttribute(SPELL_ATTR1_DISMISS_PET))
-            if (Pet* pet = ObjectAccessor::GetPet(*m_caster, unitCaster->GetPetGUID()))
+        {
+            if (Pet* pet = ObjectAccessor::GetPet(*m_caster, unitCaster->GetPetGUID())) // For Players
                 pet->DespawnOrUnsummon();
+            else if (Creature* pet = ObjectAccessor::GetCreature(*m_caster, unitCaster->GetPetGUID())) // For NPCs
+                pet->DespawnOrUnsummon();
+        }
+    }
 
     PrepareTriggersExecutedOnHit();
 


### PR DESCRIPTION
…roject-Epoch/TrinityCore/commit/26724ec217e5a8dde91c4369123a43dac240d91e

Previous commit made the attribute work for players and broke it for NPCs. We handle both cases now.

