### PR TITLE
Do not allow spell crit suppression to underflow.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7578,7 +7578,8 @@ float Unit::SpellCritChanceTaken(Unit const* caster, SpellInfo const* spellInfo,
                 if (GetTypeId() == TYPEID_UNIT)
                 {
                     int32 const levelDiff = static_cast<int32>(GetLevelForTarget(caster)) - caster->GetLevel();
-                    crit_chance -= levelDiff * 0.7f;
+                    if (levelDiff > 0)
+                        crit_chance -= levelDiff * 0.7f;
                 }
             }
             break;


### PR DESCRIPTION
There is crit suppression for spells against higher level targets, however due to the int32 used it can swing the other way and players can get free spell crit against lower level targets.

From discussions on the internal discord it seems like that was an unintended interaction (and I could not find any trace of this in vmangos/cmangos), and it also slightly reduces the power level of players.

Can choose to ignore this, of course.