### PR TITLE
allow target for SPELL_ATTR5_DONT_TURN_DURING_CAST on spell focus

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3436,18 +3436,16 @@ void Creature::SetSpellFocus(Spell const* focusSpell, WorldObject const* target)
 
     _spellFocusInfo.Spell = focusSpell;
 
-    bool const noTurnDuringCast = spellInfo->HasAttribute(SPELL_ATTR5_DONT_TURN_DURING_CAST);
-    bool const turnDisabled = HasUnitFlag2(UNIT_FLAG2_CANNOT_TURN);
     // set target, then force send update packet to players if it changed to provide appropriate facing
-    ObjectGuid newTarget = (target && !noTurnDuringCast && !turnDisabled) ? target->GetGUID() : ObjectGuid::Empty;
+    ObjectGuid newTarget = (target && !HasUnitFlag2(UNIT_FLAG2_CANNOT_TURN)) ? target->GetGUID() : ObjectGuid::Empty;
     if (GetGuidValue(UNIT_FIELD_TARGET) != newTarget)
         SetGuidValue(UNIT_FIELD_TARGET, newTarget);
 
-    // If we are not allowed to turn during cast but have a focus target, face the target
-    if (!turnDisabled && noTurnDuringCast && target)
+    // face the target
+    if (newTarget)
         SetFacingToObject(target, false);
 
-    if (noTurnDuringCast)
+    if (spellInfo->HasAttribute(SPELL_ATTR5_DONT_TURN_DURING_CAST))
         AddUnitState(UNIT_STATE_FOCUSING);
 }
 


### PR DESCRIPTION
https://github.com/Project-Epoch/TrinityCore/issues/45
As far as I can tell UNIT_STATE_FOCUSING is all we need set for creatures to not face the target on tick,
but I believe we should get and face the target on focus. (Notice this check is not done on ReacquireSpellFocusTarget)

This sets the UNIT_FIELD_TARGET in this case and sets the creature to face it.

I am assuming some order of operations, racecondition, or something was causing
if (!turnDisabled && noTurnDuringCast && target) SetFacingToObject(target, false)
to sometimes not work.

Currently testing this and will report findings...

Update:
The mages in deadmines were a good unit to test with, as Flamestrike is one of these no turn while casting spells.
It can be tricky to get this issue to show, as the mages will generally path a bit towards you before locking in to cast, but occasionally they will immediately cast when breaking from their patrol, which will display this 'turn away' behavior.
I was able to reproduce the issue on the main branch several times so that I knew what I was looking for.
With this fix in place and I coaxed a few mages into a flamestrike immediately out of their patrol and verified the mages did indeed turn to face the player immediately before casting and stayed locked in a direction during the cast.
