### PR TITLE
Fix wander distance crash

### DIFF
--- a/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
@@ -157,7 +157,7 @@ void RandomMovementGenerator<Creature>::SetRandomLocation(Creature* owner)
         else
         {
             position = _reference;
-            float distance = frand(MIN_WANDER_DISTANCE, _wanderDistance);
+            float distance = frand(MIN_WANDER_DISTANCE, std::max(MIN_WANDER_DISTANCE, _wanderDistance));
             float angle = _angles[_angleIndex];
             _angleIndex = (_angleIndex + 1) % NUM_WANDER_POINTS;
             // Project destination position to the first collision


### PR DESCRIPTION
Some creatures or calls to random movement generator were passed a wander distance <= 1, which broke the random wander frand call since it overrides the minimum.  This ensures the frand call sets the max to whatever the _wander distance is and the min.
