### PR TITLE
Spirit of Redemption Aura Apply (176) Remove in flight spells

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1570,6 +1570,7 @@ void AuraEffect::HandleSpiritOfRedemption(AuraApplication const* aurApp, uint8 m
         }
 
         target->SetHealth(1);
+        target->SetImmuneToAll(true, true);
     }
     // die at aura end
     else if (target->IsAlive())

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -34,6 +34,7 @@
 #include "Player.h"
 #include "ReputationMgr.h"
 #include "ScriptMgr.h"
+#include "SharedDefines.h"
 #include "Spell.h"
 #include "SpellHistory.h"
 #include "SpellMgr.h"
@@ -1570,7 +1571,11 @@ void AuraEffect::HandleSpiritOfRedemption(AuraApplication const* aurApp, uint8 m
         }
 
         target->SetHealth(1);
-        target->SetImmuneToAll(true, true);
+        // Copied from sanctuary to fix in flight spells stun/sleep/killing priest
+        target->InterruptSpellsCastedOnMe(true);
+        target->InterruptAttacksOnMe(0.0f);
+        // makes spells cast before this time fizzle
+        target->m_lastSanctuaryTime = GameTime::GetGameTimeMS();
     }
     // die at aura end
     else if (target->IsAlive())

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -34,7 +34,6 @@
 #include "Player.h"
 #include "ReputationMgr.h"
 #include "ScriptMgr.h"
-#include "SharedDefines.h"
 #include "Spell.h"
 #include "SpellHistory.h"
 #include "SpellMgr.h"

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -34,6 +34,7 @@
 #include "Player.h"
 #include "ReputationMgr.h"
 #include "ScriptMgr.h"
+#include "SharedDefines.h"
 #include "Spell.h"
 #include "SpellHistory.h"
 #include "SpellMgr.h"
@@ -1570,11 +1571,16 @@ void AuraEffect::HandleSpiritOfRedemption(AuraApplication const* aurApp, uint8 m
         }
 
         target->SetHealth(1);
+
         // Copied from sanctuary to fix in flight spells stun/sleep/killing priest
         target->InterruptSpellsCastedOnMe(true);
         target->InterruptAttacksOnMe(0.0f);
         // makes spells cast before this time fizzle
         target->m_lastSanctuaryTime = GameTime::GetGameTimeMS();
+
+        // Since these immunities must be missing from the spell itself, we can add them manually
+        target->ApplySpellImmune(0, IMMUNITY_SCHOOL, SPELL_SCHOOL_MASK_ALL, true);
+        target->ApplySpellImmune(0, IMMUNITY_MECHANIC, IMMUNE_TO_MOVEMENT_IMPAIRMENT_AND_LOSS_CONTROL_MASK, true);
     }
     // die at aura end
     else if (target->IsAlive())


### PR DESCRIPTION
From looking at the spell:

// Passive Used
20711- dummy(4) and increase spirit(137), if killed while have it cast spirit of redemption
// Not sure if used, but looks similar to 20711
35618- spell aura school absorb (69), spirit(137)

// Cast on Kill
Manually checks if (AuraEffect const* aurEff = victim->GetAuraEffect(SPELL_AURA_DUMMY, SPELLFAMILY_PRIEST, 0, 0, 0x200))
which is the passive given by 20711 that its active, if so casts
27827- heal, water breathing, shapeshift

// On shapeshift as a result of 27827
27792- unattackable, zero mana cost, root in place
27795- pacify, 176 (spirit of redemption aura), interrupt regen

All of the reactive auras do everything but prevent in-flight attacks.
Ways to fix:
Edit DBCs:
-Modify any of the spells that get set to include the immunities
-Add auras with specific immunities

Not Edit DBCs:
-Manually Modify 176 aura handler to include the properties you want set.

I chose the later option.