### PR TITLE
Recalc power cost right at the end of casting

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3555,7 +3555,7 @@ void Spell::_cast(bool skipCheck)
     {
         /** @epoch-start  */
         // recalculate cost one final time to handle clearcasting better
-        m_powerCost = m_spellInfo->CalcPowerCost(m_caster, m_spellSchoolMask);
+        m_powerCost = m_CastItem ? 0 : m_spellInfo->CalcPowerCost(m_caster, m_spellSchoolMask, this);
         /** @epoch-end */
 
         // Powers have to be taken before SendSpellGo

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3553,6 +3553,11 @@ void Spell::_cast(bool skipCheck)
 
     if (!(_triggeredCastFlags & TRIGGERED_IGNORE_POWER_AND_REAGENT_COST))
     {
+        /** @epoch-start  */
+        // recalculate cost one final time to handle clearcasting better
+        m_powerCost = m_spellInfo->CalcPowerCost(m_caster, m_spellSchoolMask);
+        /** @epoch-end */
+
         // Powers have to be taken before SendSpellGo
         TakePower();
         TakeReagents();                                         // we must remove reagents before HandleEffects to allow place crafted item in same slot


### PR DESCRIPTION
In theory should resolve part of https://github.com/Project-Epoch/bugtracker/issues/2749

```
effect applies to spells with a delay, same as mage clearcasting: it isn't buffing the next spell that is already being cast as it should (spell should check for buff present when finishing cast), instead it only buffs the second spell afterwards, the spell checks for the effect being present when the cast begins instead - this leads to several procs being lost unused
```

The spell system scares me I want a review of this.