### PR TITLE
Weapon Damage Types Unlock and Remove flat spell bonuses from melee calculation

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -280,7 +280,7 @@ bool ForcedDespawnDelayEvent::Execute(uint64 /*e_time*/, uint32 /*p_time*/)
 Creature::Creature(bool isWorldObject): Unit(isWorldObject), MapObject(), m_groupLootTimer(0), lootingGroupLowGUID(0), m_PlayerDamageReq(0), m_lootRecipient(), m_lootRecipientGroup(0), _pickpocketLootRestore(0),
     m_corpseRemoveTime(0), m_respawnTime(0), m_respawnDelay(300), m_corpseDelay(60), m_respawnAggroDelay(5000), m_ignoreCorpseDecayRatio(false), m_wanderDistance(0.0f), m_boundaryCheckTime(2500), m_backpedalTime(MOVE_BACKWARDS_CHECK_INTERVAL), m_encircleTime(MOVE_CIRCLE_CHECK_INTERVAL), m_combatPulseTime(0), m_combatPulseDelay(0), m_reactState(REACT_AGGRESSIVE),
     m_defaultMovementType(IDLE_MOTION_TYPE), m_spawnId(0), m_equipmentId(0), m_originalEquipmentId(0), m_AlreadyCallAssistance(false), m_InitialAggroCallAssistance(true), m_AlreadySearchedAssistance(false), m_cannotReachTarget(false), m_cannotReachTimer(0),
-    m_meleeDamageSchoolMask(SPELL_SCHOOL_MASK_NORMAL), m_originalEntry(0), m_homePosition(), m_transportHomePosition(), m_creatureInfo(nullptr), m_creatureData(nullptr), m_detectionDistance(20.0f), _waypointPathId(0),
+    m_meleeDamageSchool(SPELL_SCHOOL_NORMAL), m_originalEntry(0), m_homePosition(), m_transportHomePosition(), m_creatureInfo(nullptr), m_creatureData(nullptr), m_detectionDistance(20.0f), _waypointPathId(0),
     m_formation(nullptr), m_triggerJustAppeared(true), m_respawnCompatibilityMode(false), m_lastLeashExtensionTime(nullptr),
     _currentWaypointNodeInfo(0, 0), _regenerateHealth(true), _regenerateHealthLock(false), _isMissingCanSwimFlagOutOfCombat(false), m_assistanceTimer(0), m_forcePowerRegen(false),
     m_BaseAttackPower(0), m_BaseRangedAttackPower(0)

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -192,7 +192,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         void UpdateMaxHealth() override;
         void UpdateMaxPower(Powers power) override;
         void UpdateAttackPowerAndDamage(bool ranged = false) override;
-        void CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, bool addTotalPct, float& minDamage, float& maxDamage, uint8 damageIndex) const override;
+        void CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, float& minDamage, float& maxDamage, uint8 damageIndex) const override;
 
         void SetCanDualWield(bool value) override;
         int8 GetOriginalEquipmentId() const { return m_originalEquipmentId; }

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -175,8 +175,9 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
 
         uint32 GetShieldBlockValue() const override;
 
-        SpellSchoolMask GetMeleeDamageSchoolMask(WeaponAttackType /*attackType*/ = BASE_ATTACK, uint8 /*damageIndex*/ = 0) const override { return m_meleeDamageSchoolMask; }
-        void SetMeleeDamageSchool(SpellSchools school) { m_meleeDamageSchoolMask = SpellSchoolMask(1 << school); }
+        SpellSchoolMask GetMeleeDamageSchoolMask(WeaponAttackType /*attackType*/ = BASE_ATTACK, uint8 /*damageIndex*/ = 0) const override { return SpellSchoolMask(1 << m_meleeDamageSchool); }
+        SpellSchools GetMeleeDamageSchool(WeaponAttackType /*attackType*/ = BASE_ATTACK, uint8 /*damageIndex*/ = 0) const override { return m_meleeDamageSchool; }
+        void SetMeleeDamageSchool(SpellSchools school) { m_meleeDamageSchool = school; }
 
         bool HasSpell(uint32 spellID) const override;
 
@@ -457,7 +458,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         bool m_cannotReachTarget;
         uint32 m_cannotReachTimer;
 
-        SpellSchoolMask m_meleeDamageSchoolMask;
+        SpellSchools m_meleeDamageSchool;
         uint32 m_originalEntry;
 
         Position m_homePosition;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5350,8 +5350,8 @@ void Player::UpdateDamageDoneMods(WeaponAttackType attackType, int32 skipEnchant
         }
     }
 
-    // TODO Adding elemental damage type elements is supported here but would require
-    // additional changes in DBC and likely the client
+    // TODO it is now possible with HandleDamageFlatModifier to add elemental flat bonuses (elemental damage enchants)
+    // but that would require additional support in the client
     HandleDamageFlatModifier(unitMod, SPELL_SCHOOL_NORMAL, amount, true);
 }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5350,7 +5350,8 @@ void Player::UpdateDamageDoneMods(WeaponAttackType attackType, int32 skipEnchant
         }
     }
 
-    HandleStatFlatModifier(unitMod, TOTAL_VALUE, amount, true);
+    // TODO handle other damage type enchants
+    HandleDamageFlatModifier(unitMod, SPELL_SCHOOL_NORMAL, amount, true);
 }
 
 void Player::UpdateBaseModGroup(BaseModGroup modGroup)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5352,6 +5352,7 @@ void Player::UpdateDamageDoneMods(WeaponAttackType attackType, int32 skipEnchant
 
     // TODO it is now possible with HandleDamageFlatModifier to add elemental flat bonuses (elemental damage enchants)
     // but that would require additional support in the client
+    TC_LOG_DEBUG("damagetypes", "Player::UpdateDamageDoneMods: {} {} {}", unitMod, SPELL_SCHOOL_NORMAL, amount);
     HandleDamageFlatModifier(unitMod, SPELL_SCHOOL_NORMAL, amount, true);
 }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5352,7 +5352,7 @@ void Player::UpdateDamageDoneMods(WeaponAttackType attackType, int32 skipEnchant
     }
 
     // For +damage enchants and rockbiter we add flat mods to the primary weapon's spell school
-    SpellSchools school = GetMeleeDamageSchool(attType, 0);
+    SpellSchools school = GetMeleeDamageSchool(attackType, 0);
     HandleDamageFlatModifier(unitMod, school, amount, true);
 }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -83,6 +83,7 @@
 #include "QuestPools.h"
 #include "Realm.h"
 #include "ReputationMgr.h"
+#include "SharedDefines.h"
 #include "SkillDiscovery.h"
 #include "SocialMgr.h"
 #include "Spell.h"
@@ -5342,7 +5343,7 @@ void Player::UpdateDamageDoneMods(WeaponAttackType attackType, int32 skipEnchant
                     break;
                 case ITEM_ENCHANTMENT_TYPE_TOTEM:
                     if (GetClass() == CLASS_SHAMAN)
-                        amount += enchantmentEntry->EffectPointsMin[i] * item->GetTemplate()->Delay / 1000.0f;
+                        amount += enchantmentEntry->EffectPointsMin[i] * item->GetTemplate()->Delay / 1000.0f; // Wrath Rockbiter increases dps by flat amount
                     break;
                 default:
                     break;
@@ -5350,9 +5351,9 @@ void Player::UpdateDamageDoneMods(WeaponAttackType attackType, int32 skipEnchant
         }
     }
 
-    // TODO it is now possible with HandleDamageFlatModifier to add elemental flat bonuses (elemental damage enchants)
-    // but that would require additional support in the client
-    HandleDamageFlatModifier(unitMod, SPELL_SCHOOL_NORMAL, amount, true);
+    // For +damage enchants and rockbiter we add flat mods to the primary weapon's spell school
+    SpellSchools school = GetMeleeDamageSchool(attType, 0);
+    HandleDamageFlatModifier(unitMod, school, amount, true);
 }
 
 void Player::UpdateBaseModGroup(BaseModGroup modGroup)
@@ -7802,10 +7803,15 @@ void Player::_ApplyWeaponDamage(uint8 slot, ItemTemplate const* proto, bool appl
 
 SpellSchoolMask Player::GetMeleeDamageSchoolMask(WeaponAttackType attackType /*= BASE_ATTACK*/, uint8 damageIndex /*= 0*/) const
 {
-    if (Item const* weapon = GetWeaponForAttack(attackType, true))
-        return SpellSchoolMask(1 << weapon->GetTemplate()->Damage[damageIndex].DamageType);
+    return SpellSchoolMask(1 << GetMeleeDamageSchool(attackType, damageIndex));
+}
 
-    return SPELL_SCHOOL_MASK_NORMAL;
+SpellSchools Player::GetMeleeDamageSchool(WeaponAttackType attackType /*= BASE_ATTACK*/, uint8 damageIndex /*= 0*/) const
+{
+    if (Item const* weapon = GetWeaponForAttack(attackType, true))
+        return SpellSchools(weapon->GetTemplate()->Damage[damageIndex].DamageType);
+
+    return SPELL_SCHOOL_NORMAL;
 }
 
 void Player::CastAllObtainSpells()

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5350,7 +5350,8 @@ void Player::UpdateDamageDoneMods(WeaponAttackType attackType, int32 skipEnchant
         }
     }
 
-    // TODO handle other damage type enchants
+    // TODO Adding elemental damage type elements is supported here but would require
+    // additional changes in DBC and likely the client
     HandleDamageFlatModifier(unitMod, SPELL_SCHOOL_NORMAL, amount, true);
 }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5352,7 +5352,6 @@ void Player::UpdateDamageDoneMods(WeaponAttackType attackType, int32 skipEnchant
 
     // TODO it is now possible with HandleDamageFlatModifier to add elemental flat bonuses (elemental damage enchants)
     // but that would require additional support in the client
-    TC_LOG_DEBUG("damagetypes", "Player::UpdateDamageDoneMods: {} {} {}", unitMod, SPELL_SCHOOL_NORMAL, amount);
     HandleDamageFlatModifier(unitMod, SPELL_SCHOOL_NORMAL, amount, true);
 }
 

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1911,6 +1911,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void ResetAllPowers();
 
         SpellSchoolMask GetMeleeDamageSchoolMask(WeaponAttackType attackType = BASE_ATTACK, uint8 damageIndex = 0) const override;
+        SpellSchools GetMeleeDamageSchool(WeaponAttackType attackType = BASE_ATTACK, uint8 damageIndex = 0) const override;
 
         void CastAllObtainSpells();
         void ApplyItemObtainSpells(Item* item, bool apply);

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1671,7 +1671,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void UpdateRating(CombatRating cr);
         void UpdateAllRatings();
 
-        void CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, bool addTotalPct, float& minDamage, float& maxDamage, uint8 damageIndex) const override;
+        void CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, float& minDamage, float& maxDamage, uint8 damageIndex) const override;
 
         void UpdateDefenseBonusesMod();
         void RecalculateRating(CombatRating cr) { ApplyRatingMod(cr, 0, true);}

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -872,6 +872,7 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, fl
     float basePct = GetPctModifierValue(unitMod, BASE_PCT);
 
     // Players have their mod damage auras per school
+    SpellSchools school = GetFirstSchoolInMask(GetMeleeDamageSchoolMask(attType, damageIndex));
     float totalValue = GetDamageFlatModifierValue(unitMod, school);
     float totalPct = GetDamagePctModifierValue(unitMod, school);
 

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -805,17 +805,48 @@ void Player::UpdateShieldBlockValue()
 
 void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, float& minDamage, float& maxDamage, uint8 damageIndex) const
 {
-    SpellSchools school = GetFirstSchoolInMask(GetMeleeDamageSchoolMask(attType, damageIndex));
-    float weaponMinDamage = GetWeaponDamageRange(attType, MINDAMAGE, damageIndex);
-    float weaponMaxDamage = GetWeaponDamageRange(attType, MAXDAMAGE, damageIndex);
+    float apFraction = 1.0f;
+    float weaponMinDamage = GetWeaponDamageRange(attType, MINDAMAGE, 1);
+    float weaponMaxDamage = GetWeaponDamageRange(attType, MAXDAMAGE, 1);
+    float weaponAverageDamage = (weaponMinDamage + weaponMaxDamage) / 2;
 
-    // Try this extra check for secondary damage
-    if (damageIndex != 0 && (weaponMinDamage <= 0 || weaponMaxDamage <= 0))
+    // When no/invalid secondary damage slot
+    if (weaponMinDamage <= 0 || weaponMaxDamage <= 0)
     {
-        minDamage = 0.f;
-        maxDamage = 0.f;
-        return;
+        // If calculating secondary slot return 0 damage, only base/defaults for primary slot
+        if (damageIndex == 1)
+        {
+            minDamage = 0.f;
+            maxDamage = 0.f;
+            return;
+        }
     }
+    // We have secondary damage, so we need to calculate AP fraction depending on the slot we are calculating
+    else
+    {
+        // If calculating the secondary slot
+        if (damageIndex == 1)
+        {
+            float otherWeaponMinDamage = GetWeaponDamageRange(attType, MINDAMAGE, 0);
+            float otherWeaponMaxDamage = GetWeaponDamageRange(attType, MAXDAMAGE, 0);
+            float otherWeaponAverageDamage = (otherWeaponMinDamage + otherWeaponMaxDamage) / 2;
+        }
+        // If calculating the primary slot
+        else
+        {
+            float otherWeaponMinDamage = weaponMinDamage;
+            float otherWeaponMaxDamage = weaponMaxDamage;
+            float otherWeaponAverageDamage = weaponAverageDamage;
+            weaponMinDamage = GetWeaponDamageRange(attType, MINDAMAGE, 0);
+            weaponMaxDamage = GetWeaponDamageRange(attType, MAXDAMAGE, 0);
+            weaponAverageDamage = (weaponMinDamage + weaponMaxDamage) / 2;
+        }
+
+        apFraction = weaponAverageDamage / (weaponAverageDamage + otherWeaponAverageDamage);
+    }
+
+    if (attType == BASE_ATTACK)
+        TC_LOG_DEBUG("damagetypes", "INDEX {} CalculateMinMaxDamage normalized: {}, weaponMinDamage: {}, weaponMaxDamage: {}, apFraction: {}", damageIndex, normalized, weaponMinDamage, weaponMaxDamage, apFraction);
 
     UnitMods unitMod;
 
@@ -836,7 +867,7 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, fl
     float const attackPowerMod = std::max(GetAPMultiplier(attType, normalized), 0.25f);
 
     float baseValue  = GetFlatModifierValue(unitMod, BASE_VALUE);
-    baseValue += GetTotalAttackPowerValue(attType) / 14.0f * attackPowerMod;
+    baseValue += GetTotalAttackPowerValue(attType) / 14.0f * attackPowerMod * apFraction;
 
     float basePct = GetPctModifierValue(unitMod, BASE_PCT);
 

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -805,6 +805,20 @@ void Player::UpdateShieldBlockValue()
 
 void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, float& minDamage, float& maxDamage, uint8 damageIndex) const
 {
+    SpellSchools school = GetFirstSchoolInMask(GetMeleeDamageSchoolMask(attType, damageIndex));
+    float weaponMinDamage = GetWeaponDamageRange(attType, MINDAMAGE, damageIndex);
+    float weaponMaxDamage = GetWeaponDamageRange(attType, MAXDAMAGE, damageIndex);
+
+    TC_LOG_DEBUG("damagetypes", "CalculateMinMaxDamage attType: {}, normalized: {}, damageIndex: {}, weaponMinDamage: {}, weaponMaxDamage: {}", attType, normalized, damageIndex, weaponMinDamage, weaponMaxDamage);
+
+    // Try this extra check for secondary damage
+    if (damageIndex != 0 && (weaponMinDamage <= 0 || weaponMaxDamage <= 0))
+    {
+        minDamage = 0.f;
+        maxDamage = 0.f;
+        return;
+    }
+
     UnitMods unitMod;
 
     switch (attType)
@@ -826,15 +840,11 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, fl
     float baseValue  = GetFlatModifierValue(unitMod, BASE_VALUE);
     baseValue += GetTotalAttackPowerValue(attType) / 14.0f * attackPowerMod;
 
-    SpellSchools school = GetFirstSchoolInMask(GetMeleeDamageSchoolMask(attType, damageIndex));
+    float basePct = GetPctModifierValue(unitMod, BASE_PCT);
 
-    float basePct    = GetPctModifierValue(unitMod, BASE_PCT);
     // Players have their mod damage auras per school
     float totalValue = GetDamageFlatModifierValue(unitMod, school);
-    float totalPct   = GetDamagePctModifierValue(unitMod, school);
-
-    float weaponMinDamage = GetWeaponDamageRange(attType, MINDAMAGE, damageIndex);
-    float weaponMaxDamage = GetWeaponDamageRange(attType, MAXDAMAGE, damageIndex);
+    float totalPct = GetDamagePctModifierValue(unitMod, school);
 
     // check if player is druid and in cat or bear forms
     if (IsInFeralForm())
@@ -848,8 +858,8 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, fl
     }
     else if (!CanUseAttackType(attType)) // check if player not in form but still can't use (disarm case)
     {
-        // cannot use ranged/off attack, set values to 0
-        if (attType != BASE_ATTACK)
+        // when cannot attack for ranged/off attack or secondary damage do no damage.
+        if (attType != BASE_ATTACK || damageIndex != 0)
         {
             minDamage = 0.f;
             maxDamage = 0.f;
@@ -867,6 +877,8 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, fl
 
     minDamage = ((weaponMinDamage + baseValue) * basePct + totalValue) * totalPct;
     maxDamage = ((weaponMaxDamage + baseValue) * basePct + totalValue) * totalPct;
+
+    TC_LOG_DEBUG("damagetypes", "CalculateMinMaxDamage FINAL attType: {}, normalized: {}, damageIndex: {}, minDamage: {}, maxDamage: {}", attType, normalized, damageIndex, minDamage, maxDamage);
 }
 
 void Player::UpdateDefenseBonusesMod()

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -149,6 +149,7 @@ void Unit::UpdateAllResistances()
         UpdateResistances(i);
 }
 
+// Not physical damage, more accurately 'combined damage'
 void Unit::UpdateDamagePhysical(WeaponAttackType attType)
 {
     float totalMin = 0.f;
@@ -157,7 +158,7 @@ void Unit::UpdateDamagePhysical(WeaponAttackType attType)
     float tmpMin, tmpMax;
     for (uint8 i = 0; i < MAX_ITEM_PROTO_DAMAGES; ++i)
     {
-        CalculateMinMaxDamage(attType, false, true, tmpMin, tmpMax, i);
+        CalculateMinMaxDamage(attType, false, tmpMin, tmpMax, i);
         totalMin += tmpMin;
         totalMax += tmpMax;
     }
@@ -802,22 +803,8 @@ void Player::UpdateShieldBlockValue()
     // @tswow-end
 }
 
-void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, bool addTotalPct, float& minDamage, float& maxDamage, uint8 damageIndex) const
+void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, float& minDamage, float& maxDamage, uint8 damageIndex) const
 {
-    // Only proto damage, not affected by any mods
-    if (damageIndex != 0)
-    {
-        minDamage = 0.0f;
-        maxDamage = 0.0f;
-
-        if (!IsInFeralForm() && CanUseAttackType(attType))
-        {
-            minDamage = GetWeaponDamageRange(attType, MINDAMAGE, damageIndex);
-            maxDamage = GetWeaponDamageRange(attType, MAXDAMAGE, damageIndex);
-        }
-        return;
-    }
-
     UnitMods unitMod;
 
     switch (attType)
@@ -839,12 +826,15 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, bo
     float baseValue  = GetFlatModifierValue(unitMod, BASE_VALUE);
     baseValue += GetTotalAttackPowerValue(attType) / 14.0f * attackPowerMod;
 
-    float basePct    = GetPctModifierValue(unitMod, BASE_PCT);
-    float totalValue = GetFlatModifierValue(unitMod, TOTAL_VALUE);
-    float totalPct   = addTotalPct ? GetPctModifierValue(unitMod, TOTAL_PCT) : 1.0f;
+    SpellSchools school = GetFirstSchoolInMask(GetMeleeDamageSchoolMask(attType, damageIndex));
 
-    float weaponMinDamage = GetWeaponDamageRange(attType, MINDAMAGE);
-    float weaponMaxDamage = GetWeaponDamageRange(attType, MAXDAMAGE);
+    float basePct    = GetPctModifierValue(unitMod, BASE_PCT);
+    // Players have their mod damage auras per school
+    float totalValue = GetDamageFlatModifierValue(unitMod, school);
+    float totalPct   = GetDamagePctModifierValue(unitMod, school);
+
+    float weaponMinDamage = GetWeaponDamageRange(attType, MINDAMAGE, damageIndex);
+    float weaponMaxDamage = GetWeaponDamageRange(attType, MAXDAMAGE, damageIndex);
 
     // check if player is druid and in cat or bear forms
     if (IsInFeralForm())
@@ -1532,7 +1522,7 @@ void Creature::UpdateAttackPowerAndDamage(bool ranged)
     }
 }
 
-void Creature::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, bool addTotalPct, float& minDamage, float& maxDamage, uint8 damageIndex /*= 0*/) const
+void Creature::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, float& minDamage, float& maxDamage, uint8 damageIndex /*= 0*/) const
 {
     // creatures only have one damage
     if (damageIndex != 0)
@@ -1582,7 +1572,7 @@ void Creature::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, 
     float baseValue        = GetFlatModifierValue(unitMod, BASE_VALUE) + (attackPower / 14.0f) * variance;
     float basePct          = GetPctModifierValue(unitMod, BASE_PCT) * attackSpeedMulti;
     float totalValue       = GetFlatModifierValue(unitMod, TOTAL_VALUE);
-    float totalPct         = addTotalPct ? GetPctModifierValue(unitMod, TOTAL_PCT) : 1.0f;
+    float totalPct         = GetPctModifierValue(unitMod, TOTAL_PCT);
     float dmgMultiplier    = GetCreatureTemplate()->ModDamage; // = ModDamage * _GetDamageMod(rank);
 
     minDamage = ((weaponMinDamage + baseValue) * dmgMultiplier * basePct + totalValue) * totalPct;

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -830,6 +830,7 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, fl
             float otherWeaponMinDamage = GetWeaponDamageRange(attType, MINDAMAGE, 0);
             float otherWeaponMaxDamage = GetWeaponDamageRange(attType, MAXDAMAGE, 0);
             float otherWeaponAverageDamage = (otherWeaponMinDamage + otherWeaponMaxDamage) / 2;
+            apFraction = weaponAverageDamage / (weaponAverageDamage + otherWeaponAverageDamage);
         }
         // If calculating the primary slot
         else
@@ -840,9 +841,8 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, fl
             weaponMinDamage = GetWeaponDamageRange(attType, MINDAMAGE, 0);
             weaponMaxDamage = GetWeaponDamageRange(attType, MAXDAMAGE, 0);
             weaponAverageDamage = (weaponMinDamage + weaponMaxDamage) / 2;
+            apFraction = weaponAverageDamage / (weaponAverageDamage + otherWeaponAverageDamage);
         }
-
-        apFraction = weaponAverageDamage / (weaponAverageDamage + otherWeaponAverageDamage);
     }
 
     if (attType == BASE_ATTACK)

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -885,8 +885,8 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, fl
     }
     else if (!CanUseAttackType(attType)) // check if player not in form but still can't use (disarm case)
     {
-        // when cannot attack for ranged/off attack or secondary damage do no damage.
-        if (attType != BASE_ATTACK || damageIndex != 0)
+        // cannot use ranged/off attack, set values to 0
+        if (attType != BASE_ATTACK)
         {
             minDamage = 0.f;
             maxDamage = 0.f;

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -809,9 +809,6 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, fl
     float weaponMinDamage = GetWeaponDamageRange(attType, MINDAMAGE, damageIndex);
     float weaponMaxDamage = GetWeaponDamageRange(attType, MAXDAMAGE, damageIndex);
 
-    if (attType == BASE_ATTACK)
-        TC_LOG_DEBUG("damagetypes", "INDEX {} CalculateMinMaxDamage normalized: {}, weaponMinDamage: {}, weaponMaxDamage: {}", damageIndex, normalized, weaponMinDamage, weaponMaxDamage);
-
     // Try this extra check for secondary damage
     if (damageIndex != 0 && (weaponMinDamage <= 0 || weaponMaxDamage <= 0))
     {

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -806,12 +806,15 @@ void Player::UpdateShieldBlockValue()
 void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, float& minDamage, float& maxDamage, uint8 damageIndex) const
 {
     float apFraction = 1.0f;
-    float weaponMinDamage = GetWeaponDamageRange(attType, MINDAMAGE, 1);
-    float weaponMaxDamage = GetWeaponDamageRange(attType, MAXDAMAGE, 1);
+    float weaponMinDamage = GetWeaponDamageRange(attType, MINDAMAGE, 0);
+    float weaponMaxDamage = GetWeaponDamageRange(attType, MAXDAMAGE, 0);
     float weaponAverageDamage = (weaponMinDamage + weaponMaxDamage) / 2;
+    float otherWeaponMinDamage = GetWeaponDamageRange(attType, MINDAMAGE, 1);
+    float otherWeaponMaxDamage = GetWeaponDamageRange(attType, MAXDAMAGE, 1);
+    float otherWeaponAverageDamage = (otherWeaponMinDamage + otherWeaponMaxDamage) / 2;
 
     // When no/invalid secondary damage slot
-    if (weaponMinDamage <= 0 || weaponMaxDamage <= 0)
+    if (otherWeaponMinDamage <= 0 || otherWeaponMaxDamage <= 0)
     {
         // If calculating secondary slot return 0 damage, only base/defaults for primary slot
         if (damageIndex == 1)
@@ -824,24 +827,18 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, fl
     // We have secondary damage, so we need to calculate AP fraction depending on the slot we are calculating
     else
     {
-        // If calculating the secondary slot
-        if (damageIndex == 1)
+        // If calculating the primary slot
+        if (damageIndex == 0)
         {
-            float otherWeaponMinDamage = GetWeaponDamageRange(attType, MINDAMAGE, 0);
-            float otherWeaponMaxDamage = GetWeaponDamageRange(attType, MAXDAMAGE, 0);
-            float otherWeaponAverageDamage = (otherWeaponMinDamage + otherWeaponMaxDamage) / 2;
             apFraction = weaponAverageDamage / (weaponAverageDamage + otherWeaponAverageDamage);
         }
-        // If calculating the primary slot
+        // If calculating the secondary slot
         else
         {
-            float otherWeaponMinDamage = weaponMinDamage;
-            float otherWeaponMaxDamage = weaponMaxDamage;
-            float otherWeaponAverageDamage = weaponAverageDamage;
-            weaponMinDamage = GetWeaponDamageRange(attType, MINDAMAGE, 0);
-            weaponMaxDamage = GetWeaponDamageRange(attType, MAXDAMAGE, 0);
-            weaponAverageDamage = (weaponMinDamage + weaponMaxDamage) / 2;
-            apFraction = weaponAverageDamage / (weaponAverageDamage + otherWeaponAverageDamage);
+            apFraction = otherWeaponAverageDamage / (weaponAverageDamage + otherWeaponAverageDamage);
+            // set our other weapon damages for use below
+            weaponMinDamage = otherWeaponMinDamage;
+            weaponMaxDamage = otherWeaponMaxDamage;
         }
     }
 

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -869,7 +869,7 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, fl
     float basePct = GetPctModifierValue(unitMod, BASE_PCT);
 
     // Players have their mod damage auras per school
-    SpellSchools school = GetFirstSchoolInMask(GetMeleeDamageSchoolMask(attType, damageIndex));
+    SpellSchools school = GetMeleeDamageSchool(attType, damageIndex);
     float totalValue = GetDamageFlatModifierValue(unitMod, school);
     float totalPct = GetDamagePctModifierValue(unitMod, school);
 

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -809,7 +809,8 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, fl
     float weaponMinDamage = GetWeaponDamageRange(attType, MINDAMAGE, damageIndex);
     float weaponMaxDamage = GetWeaponDamageRange(attType, MAXDAMAGE, damageIndex);
 
-    TC_LOG_DEBUG("damagetypes", "CalculateMinMaxDamage attType: {}, normalized: {}, damageIndex: {}, weaponMinDamage: {}, weaponMaxDamage: {}", attType, normalized, damageIndex, weaponMinDamage, weaponMaxDamage);
+    if (attType == BASE_ATTACK)
+        TC_LOG_DEBUG("damagetypes", "INDEX {} CalculateMinMaxDamage normalized: {}, weaponMinDamage: {}, weaponMaxDamage: {}", damageIndex, normalized, weaponMinDamage, weaponMaxDamage);
 
     // Try this extra check for secondary damage
     if (damageIndex != 0 && (weaponMinDamage <= 0 || weaponMaxDamage <= 0))
@@ -878,7 +879,8 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, fl
     minDamage = ((weaponMinDamage + baseValue) * basePct + totalValue) * totalPct;
     maxDamage = ((weaponMaxDamage + baseValue) * basePct + totalValue) * totalPct;
 
-    TC_LOG_DEBUG("damagetypes", "CalculateMinMaxDamage FINAL attType: {}, normalized: {}, damageIndex: {}, minDamage: {}, maxDamage: {}", attType, normalized, damageIndex, minDamage, maxDamage);
+    if (attType == BASE_ATTACK)
+        TC_LOG_DEBUG("damagetypes", "INDEX {} CalculateMinMaxDamage normalized: {}, minDamage: {}, maxDamage: {}", damageIndex, normalized, minDamage, maxDamage);
 }
 
 void Player::UpdateDefenseBonusesMod()

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9588,7 +9588,7 @@ void Unit::HandleStatFlatModifier(UnitMods unitMod, UnitModifierFlatType modifie
 void Unit::HandleDamageFlatModifier(UnitMods unitMod, SpellSchools school, float amount, bool apply)
 {
     uint32 unitModOffset = unitMod - UNIT_MOD_DAMAGE_MAINHAND;
-    if (school >= MAX_SPELL_SCHOOL || unitModOffset >= 2)
+    if (school >= MAX_SPELL_SCHOOL || unitModOffset >= 3)
     {
         TC_LOG_ERROR("entities.unit", "ERROR in HandleDamageFlatModifier(): non-existing SpellSchools or wrong UnitModOffset!");
         return;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1645,8 +1645,8 @@ void Unit::DealMeleeDamage(CalcDamageInfo* damageInfo, bool durabilityLoss)
             uint32 damage = aurEff->GetAmount();
             if (Unit* caster = aurEff->GetCaster())
             {
-                damage = caster->SpellDamageBonusDone(this, spellInfo, spellInfo->GetSchoolMask(), damage, SPELL_DIRECT_DAMAGE, 1, aurEff->GetSpellEffectInfo(), { });
-                damage = SpellDamageBonusTaken(caster, spellInfo, spellInfo->GetSchoolMask(), damage, SPELL_DIRECT_DAMAGE);
+                damage = caster->SpellDamageBonusDone(this, spellInfo, damage, SPELL_DIRECT_DAMAGE, 1, aurEff->GetSpellEffectInfo(), { });
+                damage = SpellDamageBonusTaken(caster, spellInfo, damage, SPELL_DIRECT_DAMAGE);
             }
 
             // No Unit::CalcAbsorbResist here - opcode doesn't send that data - this damage is probably not affected by that
@@ -6844,7 +6844,7 @@ void Unit::EnergizeBySpell(Unit* victim, SpellInfo const* spellInfo, int32 damag
     SendEnergizeSpellLog(victim, spellInfo->Id, damage, powerType);
 }
 
-uint32 Unit::SpellDamageBonusDone(Unit* victim, SpellInfo const* spellProto, SpellSchoolMask schoolMask, uint32 pdamage, DamageEffectType damagetype, uint32 totalTicks, SpellEffectInfo const& spellEffectInfo, Optional<float> const& donePctTotal, uint32 stack /*= 1*/) const
+uint32 Unit::SpellDamageBonusDone(Unit* victim, SpellInfo const* spellProto, uint32 pdamage, DamageEffectType damagetype, uint32 totalTicks, SpellEffectInfo const& spellEffectInfo, Optional<float> const& donePctTotal, uint32 stack /*= 1*/) const
 {
     // Spell Auras with infinite ticks should be calculated as if they had 1 tick
     totalTicks = std::max(totalTicks, 1u);
@@ -6859,11 +6859,11 @@ uint32 Unit::SpellDamageBonusDone(Unit* victim, SpellInfo const* spellProto, Spe
     // For totems get damage bonus from owner
     if (GetTypeId() == TYPEID_UNIT && IsTotem())
         if (Unit* owner = GetOwner())
-            return owner->SpellDamageBonusDone(victim, spellProto, schoolMask, pdamage, damagetype, totalTicks, spellEffectInfo, donePctTotal, stack);
+            return owner->SpellDamageBonusDone(victim, spellProto, pdamage, damagetype, totalTicks, spellEffectInfo, donePctTotal, stack);
 
     float ApCoeffMod = 1.0f;
     int32 DoneTotal = 0;
-    float DoneTotalMod = donePctTotal ? *donePctTotal : SpellDamagePctDone(victim, spellProto, schoolMask, damagetype);
+    float DoneTotalMod = donePctTotal ? *donePctTotal : SpellDamagePctDone(victim, spellProto, damagetype);
 
     // done scripted mod (take it from owner)
     Unit const* owner = GetOwner() ? GetOwner() : this;
@@ -6924,9 +6924,9 @@ uint32 Unit::SpellDamageBonusDone(Unit* victim, SpellInfo const* spellProto, Spe
     }
 
     // Done fixed damage bonus auras
-    int32 DoneAdvertisedBenefit  = SpellBaseDamageBonusDone(schoolMask);
+    int32 DoneAdvertisedBenefit  = SpellBaseDamageBonusDone(spellProto->GetSchoolMask());
     // modify spell power by victim's SPELL_AURA_MOD_DAMAGE_TAKEN auras (eg Amplify/Dampen Magic)
-    DoneAdvertisedBenefit += victim->GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_TAKEN, schoolMask);
+    DoneAdvertisedBenefit += victim->GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_TAKEN, spellProto->GetSchoolMask());
 
     // Pets just add their bonus damage to their spell damage
     // note that their spell damage is just gain of their own auras
@@ -6966,7 +6966,7 @@ uint32 Unit::SpellDamageBonusDone(Unit* victim, SpellInfo const* spellProto, Spe
     {
         // @epoch-start
         // Physical spells should not gain spell damage modifiers
-        if (schoolMask & SPELL_SCHOOL_MASK_NORMAL)
+        if (spellProto->GetSchoolMask() & SPELL_SCHOOL_MASK_NORMAL)
             DoneAdvertisedBenefit = 0;
         // @epoch-end
 
@@ -6993,7 +6993,7 @@ uint32 Unit::SpellDamageBonusDone(Unit* victim, SpellInfo const* spellProto, Spe
     return uint32(std::max(tmpDamage, 0.0f));
 }
 
-float Unit::SpellDamagePctDone(Unit* victim, SpellInfo const* spellProto, SpellSchoolMask schoolMask, DamageEffectType damagetype) const
+float Unit::SpellDamagePctDone(Unit* victim, SpellInfo const* spellProto, DamageEffectType damagetype) const
 {
     if (!spellProto || !victim || damagetype == DIRECT_DAMAGE)
         return 1.0f;
@@ -7009,7 +7009,7 @@ float Unit::SpellDamagePctDone(Unit* victim, SpellInfo const* spellProto, SpellS
     // For totems get damage bonus from owner
     if (GetTypeId() == TYPEID_UNIT && IsTotem())
         if (Unit* owner = GetOwner())
-            return owner->SpellDamagePctDone(victim, spellProto, schoolMask, damagetype);
+            return owner->SpellDamagePctDone(victim, spellProto, damagetype);
 
     // Done total percent damage auras
     float DoneTotalMod = 1.0f;
@@ -7022,9 +7022,9 @@ float Unit::SpellDamagePctDone(Unit* victim, SpellInfo const* spellProto, SpellS
     if (GetTypeId() == TYPEID_PLAYER)
     {
         // Get the SPELL_AURA_MOD_DAMAGE_PERCENT_DONE as it pertains to the spell being cast (wand spec)
-        maxModDamagePercentSchool = GetTotalAuraMultiplier(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE, [spellProto, schoolMask](AuraEffect const* aurEff) -> bool
+        maxModDamagePercentSchool = GetTotalAuraMultiplier(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE, [spellProto](AuraEffect const* aurEff) -> bool
         {
-            if (!(aurEff->GetMiscValue() & schoolMask))
+            if (!(aurEff->GetMiscValue() & spellProto->GetSchoolMask()))
                 return false;
 
             // If the aura expects a subclassmask then the spell must match it
@@ -7033,7 +7033,7 @@ float Unit::SpellDamagePctDone(Unit* victim, SpellInfo const* spellProto, SpellS
         });
     }
     else
-        maxModDamagePercentSchool = GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE, schoolMask);
+        maxModDamagePercentSchool = GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE, spellProto->GetSchoolMask());
 
     DoneTotalMod *= maxModDamagePercentSchool;
 
@@ -7316,7 +7316,7 @@ float Unit::SpellDamagePctDone(Unit* victim, SpellInfo const* spellProto, SpellS
     return DoneTotalMod;
 }
 
-uint32 Unit::SpellDamageBonusTaken(Unit* caster, SpellInfo const* spellProto, SpellSchoolMask schoolMask, uint32 pdamage, DamageEffectType damagetype) const
+uint32 Unit::SpellDamageBonusTaken(Unit* caster, SpellInfo const* spellProto, uint32 pdamage, DamageEffectType damagetype) const
 {
     if (!spellProto || damagetype == DIRECT_DAMAGE)
         return pdamage;
@@ -7359,14 +7359,14 @@ uint32 Unit::SpellDamageBonusTaken(Unit* caster, SpellInfo const* spellProto, Sp
     {
         // from positive and negative SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN
         // multiplicative bonus, for example Dispersion + Shadowform (0.10*0.85=0.085)
-        TakenTotalMod *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, schoolMask);
+        TakenTotalMod *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, spellProto->GetSchoolMask());
 
         // From caster spells
         if (caster)
         {
-            TakenTotalMod *= GetTotalAuraMultiplier(SPELL_AURA_MOD_DAMAGE_FROM_CASTER, [caster, spellProto, schoolMask](AuraEffect const* aurEff) -> bool
+            TakenTotalMod *= GetTotalAuraMultiplier(SPELL_AURA_MOD_DAMAGE_FROM_CASTER, [caster, spellProto](AuraEffect const* aurEff) -> bool
             {
-                if ((aurEff->GetMiscValue() & schoolMask) && aurEff->GetCasterGUID() == caster->GetGUID() && aurEff->IsAffectedOnSpell(spellProto))
+                if ((aurEff->GetMiscValue() & spellProto->GetSchoolMask()) && aurEff->GetCasterGUID() == caster->GetGUID() && aurEff->IsAffectedOnSpell(spellProto))
                     return true;
                 return false;
             });
@@ -7380,7 +7380,7 @@ uint32 Unit::SpellDamageBonusTaken(Unit* caster, SpellInfo const* spellProto, Sp
         Unit::AuraEffectList const& casterIgnoreResist = caster->GetAuraEffectsByType(SPELL_AURA_MOD_IGNORE_TARGET_RESIST);
         for (AuraEffect const* aurEff : casterIgnoreResist)
         {
-            if (!(aurEff->GetMiscValue() & schoolMask))
+            if (!(aurEff->GetMiscValue() & spellProto->GetSchoolMask()))
                 continue;
 
             AddPct(damageReduction, -aurEff->GetAmount());

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8296,7 +8296,7 @@ bool Unit::IsImmunedToSpellEffect(SpellInfo const* spellInfo, SpellEffectInfo co
     return false;
 }
 
-// Calculate the melee damage bonus for AutoAttacks = Unit::CalculateMeleeDamage and Abilities = Spell::EffectWeaponDmg
+// Calculate the melee damage bonus done for AutoAttacks = Unit::CalculateMeleeDamage and Abilities = Spell::EffectWeaponDmg
 // This method assumes the primary damage mods are already factored into pdamage
 uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType attType, SpellInfo const* spellProto /*= nullptr*/, SpellSchoolMask damageSchoolMask /*= SPELL_SCHOOL_MASK_NORMAL*/)
 {
@@ -8365,26 +8365,28 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
     // Done total percent damage auras
     float DoneTotalMod = 1.0f;
 
+    // TODO: This was removed as we use the weapon's damage type in Spell::EffectWeaponDmg which should account for these
+    // We can remove this when its stable
+    // TODO: Add non-physical attack mod pct to support non-physical primary weapon damage
     // mods for SPELL_SCHOOL_MASK_NORMAL are already factored in base melee damage calculation
-    // TODO lets allow elemental damage to factor in as well!
-    if (!(damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
-    {
-        // Some spells don't benefit from pct done mods
-        if (!spellProto || !spellProto->HasAttribute(SPELL_ATTR6_LIMIT_PCT_DAMAGE_MODS))
-        {
-            float maxModDamagePercentSchool = 0.0f;
-            if (GetTypeId() == TYPEID_PLAYER)
-            {
-                for (uint32 i = SPELL_SCHOOL_HOLY; i < MAX_SPELL_SCHOOL; ++i)
-                    if (damageSchoolMask & (1 << i))
-                        maxModDamagePercentSchool = std::max(maxModDamagePercentSchool, GetFloatValue(PLAYER_FIELD_MOD_DAMAGE_DONE_PCT + i));
-            }
-            else
-                maxModDamagePercentSchool = GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE, damageSchoolMask);
+    // if (!(damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
+    // {
+    //     // Some spells don't benefit from pct done mods
+    //     if (!spellProto || !spellProto->HasAttribute(SPELL_ATTR6_LIMIT_PCT_DAMAGE_MODS))
+    //     {
+    //         float maxModDamagePercentSchool = 0.0f;
+    //         if (GetTypeId() == TYPEID_PLAYER)
+    //         {
+    //             for (uint32 i = SPELL_SCHOOL_HOLY; i < MAX_SPELL_SCHOOL; ++i)
+    //                 if (damageSchoolMask & (1 << i))
+    //                     maxModDamagePercentSchool = std::max(maxModDamagePercentSchool, GetFloatValue(PLAYER_FIELD_MOD_DAMAGE_DONE_PCT + i));
+    //         }
+    //         else
+    //             maxModDamagePercentSchool = GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE, damageSchoolMask);
 
-            DoneTotalMod *= maxModDamagePercentSchool;
-        }
-    }
+    //         DoneTotalMod *= maxModDamagePercentSchool;
+    //     }
+    // }
 
     DoneTotalMod *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_DONE_VERSUS, creatureTypeMask);
 
@@ -8480,7 +8482,7 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
     return uint32(std::max(tmpDamage, 0.0f));
 }
 
-// Calculates the MeleeDamageBonusTaken for Auto Attacks (school mask is taken from the weapon proto)
+// Calculate the melee damage bonus taken for AutoAttacks = Unit::CalculateMeleeDamage and Abilities = Spell::EffectWeaponDmg
 uint32 Unit::MeleeDamageBonusTaken(Unit* attacker, uint32 pdamage, WeaponAttackType attType, SpellInfo const* spellProto /*= nullptr*/, SpellSchoolMask damageSchoolMask /*= SPELL_SCHOOL_MASK_NORMAL*/)
 {
     if (pdamage == 0)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8296,8 +8296,8 @@ bool Unit::IsImmunedToSpellEffect(SpellInfo const* spellInfo, SpellEffectInfo co
     return false;
 }
 
-// Calculate the melee damage bonus for AutoAttack Unit::CalculateMeleeDamage
-// TODO come back and remove spellProto and all logic pertaining to it if we decide we will no longer call this from Spell::EffectWeaponDmg
+// Calculate the melee damage bonus for AutoAttacks = Unit::CalculateMeleeDamage and Abilities = Spell::EffectWeaponDmg
+// This method assumes the primary damage mods are already factored into pdamage
 uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType attType, SpellInfo const* spellProto /*= nullptr*/, SpellSchoolMask damageSchoolMask /*= SPELL_SCHOOL_MASK_NORMAL*/)
 {
     if (!victim || pdamage == 0)
@@ -8308,11 +8308,8 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
     // Done fixed damage bonus auras
     int32 DoneFlatBenefit = 0;
 
-    // ..done
+    // e.g.Beast/Elemental Slayer Enchant
     DoneFlatBenefit += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_DONE_CREATURE, creatureTypeMask);
-
-    // ..done
-    // SPELL_AURA_MOD_DAMAGE_DONE included in weapon damage
 
     // ..done (base at attack power for marked target and base at attack power for creature type)
     int32 APbonus = 0;
@@ -8338,10 +8335,38 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
         DoneFlatBenefit += int32(APbonus / 14.0f * GetAPMultiplier(attType, normalized));
     }
 
+    float coeff = 1.0f;
+    if (spellProto)
+    {
+        // For EffectWeaponDmg spells we generally treat bonus damages/AP bonuses the same as we do auto-attacks
+        // The caveat here is these are generally balanced around physical damage, so spells that convert damage to
+        // other schools (e.g. Seal of Command) can become overpowered with respect to flat bonuses.  For normal spells
+        // this is usually counteracted with a spell coefficient being applied to the flat bonus.  There is some ambiguity here
+        // of whether we should be using the spell coefficient for all spells, or using the coefficent to modify the bonus
+        // AP calculation, or only using a coefficient for non-physical spells, etc.  The Seal of Command coefficent is 0 in the
+        // DBC in any case, and its reported it should be 29%.  The cautious approach I am taking here:
+        // 1. Leave physical spells with 1.0 coefficient (which is most of them)
+        // 2. Set magic spells to 0.0 coefficient as default
+        // 3. Override specific spells we can identify
+        if (!(damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
+            coeff = 0.0f;
+
+        switch(spellProto->Id)
+        {
+            // Seal of Command
+            case 20424:
+                coeff = 0.29f;
+                break;
+        }
+    }
+
+    DoneFlatBenefit = int32(DoneFlatBenefit * coeff);
+
     // Done total percent damage auras
     float DoneTotalMod = 1.0f;
 
     // mods for SPELL_SCHOOL_MASK_NORMAL are already factored in base melee damage calculation
+    // TODO lets allow elemental damage to factor in as well!
     if (!(damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
     {
         // Some spells don't benefit from pct done mods
@@ -8436,6 +8461,7 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
     // Custom scripted damage
     if (spellProto)
     {
+        
         switch (spellProto->SpellFamilyName)
         {
             case SPELLFAMILY_DEATHKNIGHT:
@@ -8462,7 +8488,6 @@ uint32 Unit::MeleeDamageBonusTaken(Unit* attacker, uint32 pdamage, WeaponAttackT
 
     int32 TakenFlatBenefit = 0;
 
-    // ..taken
     /** @epoch-start */
     TakenFlatBenefit += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_TAKEN, damageSchoolMask);
     /** @epoch-end */
@@ -8472,13 +8497,30 @@ uint32 Unit::MeleeDamageBonusTaken(Unit* attacker, uint32 pdamage, WeaponAttackT
     else
         TakenFlatBenefit += GetTotalAuraModifier(SPELL_AURA_MOD_RANGED_DAMAGE_TAKEN);
 
+    float coeff = 1.0f;
+    if (spellProto)
+    {
+        // See MeleeDamageBonusDone above for explanation
+        if (!(damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
+            coeff = 0.0f;
+
+        switch(spellProto->Id)
+        {
+            // Seal of Command
+            case 20424:
+                coeff = 0.29f;
+                break;
+        }
+    }
+
+    TakenFlatBenefit = int32(TakenFlatBenefit * coeff);
+
     if ((TakenFlatBenefit < 0) && (pdamage < static_cast<uint32>(-TakenFlatBenefit)))
         return 0;
 
     // Taken total percent damage auras
     float TakenTotalMod = 1.0f;
 
-    // ..taken
     /** @epoch-start */
     TakenTotalMod *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, damageSchoolMask);
     /** @epoch-end */

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9594,8 +9594,6 @@ void Unit::HandleDamageFlatModifier(UnitMods unitMod, SpellSchools school, float
         return;
     }
 
-    TC_LOG_DEBUG("damagetypes", "Unit::HandleDamageFlatModifier: {} {} {} {}", unitMod, school, amount, apply);
-
     if (!amount)
         return;
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7391,7 +7391,7 @@ uint32 Unit::SpellDamageBonusTaken(Unit* caster, SpellInfo const* spellProto, ui
     }
 
     // Damage taken
-    int32 TakenAdvertisedBenefit = victim->GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_TAKEN, spellProto->GetSchoolMask());
+    int32 TakenAdvertisedBenefit = GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_TAKEN, spellProto->GetSchoolMask());
 
     // Check for table values
     float coeff = spellEffectInfo.BonusMultiplier;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8092,7 +8092,7 @@ bool Unit::IsImmunedToDamage(SpellSchoolMask schoolMask) const
     return false;
 }
 
-bool Unit::IsImmunedToDamage(SpellInfo const* spellInfo) const
+bool Unit::IsImmunedToDamage(SpellInfo const* spellInfo, SpellSchoolMask damageSchoolMask) const
 {
     if (!spellInfo)
         return false;
@@ -8104,7 +8104,10 @@ bool Unit::IsImmunedToDamage(SpellInfo const* spellInfo) const
     if (spellInfo->HasAttribute(SPELL_ATTR1_UNAFFECTED_BY_SCHOOL_IMMUNE) || spellInfo->HasAttribute(SPELL_ATTR2_UNAFFECTED_BY_AURA_SCHOOL_IMMUNE))
         return false;
 
-    if (uint32 schoolMask = spellInfo->GetSchoolMask())
+    if (damageSchoolMask == SPELL_SCHOOL_MASK_NONE)
+        damageSchoolMask = spellInfo->GetSchoolMask();
+
+    if (uint32 schoolMask = damageSchoolMask)
     {
         // If m_immuneToSchool type contain this school type, IMMUNE damage.
         uint32 schoolImmunityMask = 0;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9590,16 +9590,16 @@ void Unit::HandleStatFlatModifier(UnitMods unitMod, UnitModifierFlatType modifie
 
 void Unit::HandleDamageFlatModifier(UnitMods unitMod, SpellSchools school, float amount, bool apply)
 {
-    uint32 unitModOffset = unitMod - UNIT_MOD_DAMAGE_MAINHAND;
-    if (school >= MAX_SPELL_SCHOOL || unitModOffset >= 3)
+    if (unitMod < UNIT_MOD_DAMAGE_MAINHAND || unitMod > UNIT_MOD_DAMAGE_RANGED || school >= MAX_SPELL_SCHOOL)
     {
-        TC_LOG_ERROR("entities.unit", "ERROR in HandleDamageFlatModifier(): non-existing SpellSchools or wrong UnitModOffset!");
+        TC_LOG_ERROR("entities.unit", "ERROR in HandleDamageFlatModifier(): non-existing SpellSchools or wrong UnitMod!");
         return;
     }
 
     if (!amount)
         return;
 
+    uint32 unitModOffset = unitMod - UNIT_MOD_DAMAGE_MAINHAND;
     m_auraDamageFlatModifiersGroup[unitModOffset][school] += apply ? amount : -amount;
 
     UpdateUnitMod(unitMod);
@@ -9680,13 +9680,13 @@ float Unit::GetFlatModifierValue(UnitMods unitMod, UnitModifierFlatType modifier
 
 float Unit::GetDamageFlatModifierValue(UnitMods unitMod, SpellSchools school) const
 {
-    uint32 unitModOffset = unitMod - UNIT_MOD_DAMAGE_MAINHAND;
-    if (unitModOffset >= 3 || school >= MAX_SPELL_SCHOOL)
+    if (unitMod < UNIT_MOD_DAMAGE_MAINHAND || unitMod > UNIT_MOD_DAMAGE_RANGED || school >= MAX_SPELL_SCHOOL)
     {
-        TC_LOG_ERROR("entities.unit", "attempt to access non-existing modifier value from UnitMods!");
+        TC_LOG_ERROR("entities.unit", "attempt to access invalid modifier value from UnitMods!");
         return 0.0f;
     }
 
+    uint32 unitModOffset = unitMod - UNIT_MOD_DAMAGE_MAINHAND;
     return m_auraDamageFlatModifiersGroup[unitModOffset][school];
 }
 
@@ -9703,13 +9703,13 @@ float Unit::GetPctModifierValue(UnitMods unitMod, UnitModifierPctType modifierTy
 
 float Unit::GetDamagePctModifierValue(UnitMods unitMod, SpellSchools school) const
 {
-    uint32 unitModOffset = unitMod - UNIT_MOD_DAMAGE_MAINHAND;
-    if (unitModOffset >= 3 || school >= MAX_SPELL_SCHOOL)
+    if (unitMod < UNIT_MOD_DAMAGE_MAINHAND || unitMod > UNIT_MOD_DAMAGE_RANGED || school >= MAX_SPELL_SCHOOL)
     {
-        TC_LOG_ERROR("entities.unit", "attempt to access non-existing modifier value from UnitMods!");
+        TC_LOG_ERROR("entities.unit", "attempt to access invalid modifier value from UnitMods!");
         return 0.0f;
     }
 
+    uint32 unitModOffset = unitMod - UNIT_MOD_DAMAGE_MAINHAND;
     return m_auraDamagePctModifiersGroup[unitModOffset][school];
 }
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1646,7 +1646,7 @@ void Unit::DealMeleeDamage(CalcDamageInfo* damageInfo, bool durabilityLoss)
             if (Unit* caster = aurEff->GetCaster())
             {
                 damage = caster->SpellDamageBonusDone(this, spellInfo, damage, SPELL_DIRECT_DAMAGE, 1, aurEff->GetSpellEffectInfo(), { });
-                damage = SpellDamageBonusTaken(caster, spellInfo, damage, SPELL_DIRECT_DAMAGE);
+                damage = SpellDamageBonusTaken(caster, spellInfo, damage, SPELL_DIRECT_DAMAGE, 1, aurEff->GetSpellEffectInfo());
             }
 
             // No Unit::CalcAbsorbResist here - opcode doesn't send that data - this damage is probably not affected by that
@@ -6846,15 +6846,15 @@ void Unit::EnergizeBySpell(Unit* victim, SpellInfo const* spellInfo, int32 damag
 
 uint32 Unit::SpellDamageBonusDone(Unit* victim, SpellInfo const* spellProto, uint32 pdamage, DamageEffectType damagetype, uint32 totalTicks, SpellEffectInfo const& spellEffectInfo, Optional<float> const& donePctTotal, uint32 stack /*= 1*/) const
 {
-    // Spell Auras with infinite ticks should be calculated as if they had 1 tick
-    totalTicks = std::max(totalTicks, 1u);
-
     if (!spellProto || !victim || damagetype == DIRECT_DAMAGE)
         return pdamage;
 
     // Some spells don't benefit from done mods
     if (spellProto->HasAttribute(SPELL_ATTR3_NO_DONE_BONUS))
         return pdamage;
+
+    // Spell Auras with infinite ticks should be calculated as if they had 1 tick
+    totalTicks = std::max(totalTicks, 1u);
 
     // For totems get damage bonus from owner
     if (GetTypeId() == TYPEID_UNIT && IsTotem())
@@ -6925,8 +6925,6 @@ uint32 Unit::SpellDamageBonusDone(Unit* victim, SpellInfo const* spellProto, uin
 
     // Done fixed damage bonus auras
     int32 DoneAdvertisedBenefit  = SpellBaseDamageBonusDone(spellProto->GetSchoolMask());
-    // modify spell power by victim's SPELL_AURA_MOD_DAMAGE_TAKEN auras (eg Amplify/Dampen Magic)
-    DoneAdvertisedBenefit += victim->GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_TAKEN, spellProto->GetSchoolMask());
 
     // Pets just add their bonus damage to their spell damage
     // note that their spell damage is just gain of their own auras
@@ -6961,15 +6959,15 @@ uint32 Unit::SpellDamageBonusDone(Unit* victim, SpellInfo const* spellProto, uin
             return uint32(std::max(pdamage * DoneTotalMod, 0.0f));
     }
 
+    // @epoch-start
+    // Physical spells should not gain spell damage modifiers
+    if (spellProto->GetSchoolMask() & SPELL_SCHOOL_MASK_NORMAL)
+        DoneAdvertisedBenefit = 0;
+    // @epoch-end
+
     // Default calculation
     if (DoneAdvertisedBenefit)
     {
-        // @epoch-start
-        // Physical spells should not gain spell damage modifiers
-        if (spellProto->GetSchoolMask() & SPELL_SCHOOL_MASK_NORMAL)
-            DoneAdvertisedBenefit = 0;
-        // @epoch-end
-
         if (coeff < 0.f)
             coeff = CalculateDefaultCoefficient(spellProto, damagetype);  // As wowwiki says: C = (Cast Time / 3.5)
 
@@ -7316,11 +7314,14 @@ float Unit::SpellDamagePctDone(Unit* victim, SpellInfo const* spellProto, Damage
     return DoneTotalMod;
 }
 
-uint32 Unit::SpellDamageBonusTaken(Unit* caster, SpellInfo const* spellProto, uint32 pdamage, DamageEffectType damagetype) const
+uint32 Unit::SpellDamageBonusTaken(Unit* caster, SpellInfo const* spellProto, uint32 pdamage, DamageEffectType damagetype, uint32 totalTicks, SpellEffectInfo const& spellEffectInfo, uint32 stack /*= 1*/) const
 {
     if (!spellProto || damagetype == DIRECT_DAMAGE)
         return pdamage;
 
+    // Spell Auras with infinite ticks should be calculated as if they had 1 tick
+    totalTicks = std::max(totalTicks, 1u);
+    int32 TakenTotal = 0;
     float TakenTotalMod = 1.0f;
 
     // Mod damage from spell mechanic
@@ -7389,7 +7390,50 @@ uint32 Unit::SpellDamageBonusTaken(Unit* caster, SpellInfo const* spellProto, ui
         TakenTotalMod = 1.0f - damageReduction;
     }
 
-    float tmpDamage = pdamage * TakenTotalMod;
+    // Damage taken
+    int32 TakenAdvertisedBenefit = victim->GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_TAKEN, spellProto->GetSchoolMask());
+
+    // Check for table values
+    float coeff = spellEffectInfo.BonusMultiplier;
+    if (SpellBonusEntry const* bonus = sSpellMgr->GetSpellBonusData(spellProto->Id))
+    {
+        if (damagetype == DOT)
+            coeff = bonus->dot_damage;
+        else
+            coeff = bonus->direct_damage;
+    }
+    else
+    {
+        // No bonus damage for SPELL_DAMAGE_CLASS_NONE class spells by default
+        if (spellProto->DmgClass == SPELL_DAMAGE_CLASS_NONE)
+            return uint32(std::max(pdamage * TakenTotalMod, 0.0f));
+    }
+
+    // @epoch-start
+    // Physical spells should not gain spell damage modifiers
+    if (spellProto->GetSchoolMask() & SPELL_SCHOOL_MASK_NORMAL)
+        TakenAdvertisedBenefit = 0;
+    // @epoch-end
+
+    // Default calculation
+    if (TakenAdvertisedBenefit)
+    {
+        if (coeff < 0.f)
+            coeff = CalculateDefaultCoefficient(spellProto, damagetype);  // As wowwiki says: C = (Cast Time / 3.5)
+
+        float factorMod = CalculateSpellpowerCoefficientLevelPenalty(spellProto) * stack;
+        if (Player* modOwner = GetSpellModOwner())
+        {
+            coeff *= 100.0f;
+            modOwner->ApplySpellMod(spellProto->Id, SPELLMOD_BONUS_MULTIPLIER, coeff);
+            coeff /= 100.0f;
+        }
+
+        TakenTotal += int32(TakenAdvertisedBenefit * coeff * factorMod);
+    }
+
+    float tmpDamage = (pdamage + float(TakenTotal) / float(totalTicks)) * TakenTotalMod;
+
     return uint32(std::max(tmpDamage, 0.0f));
 }
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1273,8 +1273,8 @@ void Unit::CalculateMeleeDamage(Unit* victim, CalcDamageInfo* damageInfo, Weapon
 
         uint32 damage = CalculateDamage(damageInfo->AttackType, false, itemDamagesMask);
 
-        // Add melee damage bonus
-        damage = MeleeDamageBonusDone(damageInfo->Target, damage, damageInfo->AttackType, nullptr, schoolMask);
+        // Add additional melee damage mods to each damage component
+        damage = MeleeDamageBonusDone(damageInfo->Target, damage, damageInfo->AttackType, nullptr);
         damage = damageInfo->Target->MeleeDamageBonusTaken(this, damage, damageInfo->AttackType, nullptr, schoolMask);
 
         // Script Hook For CalculateMeleeDamage -- Allow scripts to change the Damage pre class mitigation calculations
@@ -8306,9 +8306,8 @@ bool Unit::IsImmunedToSpellEffect(SpellInfo const* spellInfo, SpellEffectInfo co
     return false;
 }
 
-// Calculate the melee damage bonus done for AutoAttacks = Unit::CalculateMeleeDamage and Abilities = Spell::EffectWeaponDmg
-// This method assumes the primary damage mods are already factored into pdamage
-uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType attType, SpellInfo const* spellProto /*= nullptr*/, SpellSchoolMask damageSchoolMask /*= SPELL_SCHOOL_MASK_NORMAL*/)
+// Calculate the additional melee damage mods done for AutoAttacks = Unit::CalculateMeleeDamage and Abilities = Spell::EffectWeaponDmg
+uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType attType, SpellInfo const* spellProto /*= nullptr*/)
 {
     if (!victim || pdamage == 0)
         return 0;
@@ -8344,33 +8343,6 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
         bool const normalized = spellProto && spellProto->HasEffect(SPELL_EFFECT_NORMALIZED_WEAPON_DMG);
         DoneFlatBenefit += int32(APbonus / 14.0f * GetAPMultiplier(attType, normalized));
     }
-
-    float coeff = 1.0f;
-    if (spellProto)
-    {
-        // For EffectWeaponDmg spells we generally treat bonus damages/AP bonuses the same as we do auto-attacks
-        // The caveat here is these are generally balanced around physical damage, so spells that convert damage to
-        // other schools (e.g. Seal of Command) can become overpowered with respect to flat bonuses.  For normal spells
-        // this is usually counteracted with a spell coefficient being applied to the flat bonus.  There is some ambiguity here
-        // of whether we should be using the spell coefficient for all spells, or using the coefficent to modify the bonus
-        // AP calculation, or only using a coefficient for non-physical spells, etc.  The Seal of Command coefficent is 0 in the
-        // DBC in any case, and its reported it should be 29%.  The cautious approach I am taking here:
-        // 1. Leave physical spells with 1.0 coefficient (which is most of them)
-        // 2. Set magic spells to 0.0 coefficient as default
-        // 3. Override specific spells we can identify
-        if (!(damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
-            coeff = 0.0f;
-
-        switch(spellProto->Id)
-        {
-            // Seal of Command
-            case 20424:
-                coeff = 0.29f;
-                break;
-        }
-    }
-
-    DoneFlatBenefit = int32(DoneFlatBenefit * coeff);
 
     // Done total percent damage auras
     float DoneTotalMod = 1.0f;
@@ -8469,7 +8441,7 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
     return uint32(std::max(tmpDamage, 0.0f));
 }
 
-// Calculate the melee damage bonus taken for AutoAttacks = Unit::CalculateMeleeDamage and Abilities = Spell::EffectWeaponDmg
+// Calculate the additional melee damage mods taken for AutoAttacks = Unit::CalculateMeleeDamage and Abilities = Spell::EffectWeaponDmg
 uint32 Unit::MeleeDamageBonusTaken(Unit* attacker, uint32 pdamage, WeaponAttackType attType, SpellInfo const* spellProto /*= nullptr*/, SpellSchoolMask damageSchoolMask /*= SPELL_SCHOOL_MASK_NORMAL*/)
 {
     if (pdamage == 0)
@@ -8477,32 +8449,15 @@ uint32 Unit::MeleeDamageBonusTaken(Unit* attacker, uint32 pdamage, WeaponAttackT
 
     int32 TakenFlatBenefit = 0;
 
-    /** @epoch-start */
-    TakenFlatBenefit += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_TAKEN, damageSchoolMask);
-    /** @epoch-end */
+    // Similar our base weapon damage, we do not apply non-physical flat mods to our non-physical melee attacks as these
+    // mods are balanced around casted spells and not melee attacks
+    if (damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL)
+        TakenFlatBenefit += GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_DAMAGE_TAKEN, damageSchoolMask);
 
     if (attType != RANGED_ATTACK)
         TakenFlatBenefit += GetTotalAuraModifier(SPELL_AURA_MOD_MELEE_DAMAGE_TAKEN);
     else
         TakenFlatBenefit += GetTotalAuraModifier(SPELL_AURA_MOD_RANGED_DAMAGE_TAKEN);
-
-    float coeff = 1.0f;
-    if (spellProto)
-    {
-        // See MeleeDamageBonusDone above for explanation
-        if (!(damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
-            coeff = 0.0f;
-
-        switch(spellProto->Id)
-        {
-            // Seal of Command
-            case 20424:
-                coeff = 0.29f;
-                break;
-        }
-    }
-
-    TakenFlatBenefit = int32(TakenFlatBenefit * coeff);
 
     if ((TakenFlatBenefit < 0) && (pdamage < static_cast<uint32>(-TakenFlatBenefit)))
         return 0;
@@ -8510,9 +8465,7 @@ uint32 Unit::MeleeDamageBonusTaken(Unit* attacker, uint32 pdamage, WeaponAttackT
     // Taken total percent damage auras
     float TakenTotalMod = 1.0f;
 
-    /** @epoch-start */
     TakenTotalMod *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, damageSchoolMask);
-    /** @epoch-end */
 
     // .. taken pct (special attacks)
     if (spellProto)
@@ -9821,6 +9774,11 @@ void Unit::UpdateDamageDoneMods(WeaponAttackType attackType, int32 /*skipEnchant
         float amount = GetTotalAuraModifier(SPELL_AURA_MOD_DAMAGE_DONE, [&](AuraEffect const* aurEff) -> bool
         {
             if (!(aurEff->GetMiscValue() & (1 << school)))
+                return false;
+
+            // for now, most spell flat modifiers are far too powerful to add to our weapon damage mods
+            // we still want to create the bucket so we can add enchants to it and make exceptions down the road
+            if (!(aurEff->GetMiscValue() & SPELL_SCHOOL_MASK_NORMAL))
                 return false;
 
             return CheckAttackFitToAuraRequirement(attackType, aurEff);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -62,6 +62,7 @@
 #include "QuestDef.h"
 #include "ReputationMgr.h"
 #include "ScheduledChangeAI.h"
+#include "SharedDefines.h"
 #include "SpellAuraEffects.h"
 #include "SpellAuras.h"
 #include "Spell.h"
@@ -355,7 +356,18 @@ Unit::Unit(bool isWorldObject) :
         m_auraPctModifiersGroup[i][BASE_PCT] = 1.0f;
         m_auraPctModifiersGroup[i][TOTAL_PCT] = 1.0f;
     }
-                                                            // implement 50% base damage from offhand
+
+    for (uint8 i = 0; i < MAX_SPELL_SCHOOL; ++i)
+    {
+        m_auraDamageFlatModifiersGroup[0][i] = 0.0f;
+        m_auraDamageFlatModifiersGroup[1][i] = 0.0f;
+        m_auraDamageFlatModifiersGroup[2][i] = 0.0f;
+        m_auraDamagePctModifiersGroup[0][i] = 1.0f;
+        m_auraDamagePctModifiersGroup[1][i] = 1.0f;
+        m_auraDamagePctModifiersGroup[2][i] = 1.0f;
+    }
+
+    // implement 50% base damage from offhand
     m_auraPctModifiersGroup[UNIT_MOD_DAMAGE_OFFHAND][TOTAL_PCT] = 0.5f;
 
     for (uint8 i = 0; i < MAX_ATTACK; ++i)
@@ -1257,11 +1269,9 @@ void Unit::CalculateMeleeDamage(Unit* victim, CalcDamageInfo* damageInfo, Weapon
 
         SpellSchoolMask schoolMask = SpellSchoolMask(damageInfo->Damages[i].DamageSchoolMask);
 
-        bool const addPctMods = (schoolMask & SPELL_SCHOOL_MASK_NORMAL);
-
         uint8 itemDamagesMask = (GetTypeId() == TYPEID_PLAYER) ? (1 << i) : 0;
 
-        uint32 damage = CalculateDamage(damageInfo->AttackType, false, addPctMods, itemDamagesMask);
+        uint32 damage = CalculateDamage(damageInfo->AttackType, false, itemDamagesMask);
 
         // Add melee damage bonus
         damage = MeleeDamageBonusDone(damageInfo->Target, damage, damageInfo->AttackType, nullptr, schoolMask);
@@ -1279,7 +1289,7 @@ void Unit::CalculateMeleeDamage(Unit* victim, CalcDamageInfo* damageInfo, Weapon
         // @tswow-end
 
         // Calculate armor reduction
-        if (Unit::IsDamageReducedByArmor(SpellSchoolMask(damageInfo->Damages[i].DamageSchoolMask)))
+        if (Unit::IsDamageReducedByArmor(schoolMask))
         {
             damageInfo->Damages[i].Damage = Unit::CalcArmorReducedDamage(damageInfo->Attacker, damageInfo->Target, damage, nullptr, damageInfo->AttackType);
             damageInfo->CleanDamage += damage - damageInfo->Damages[i].Damage;
@@ -2414,12 +2424,12 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(Unit const* victim, WeaponAttackTy
     return MELEE_HIT_NORMAL;
 }
 
-uint32 Unit::CalculateDamage(WeaponAttackType attType, bool normalized, bool addTotalPct, uint8 itemDamagesMask /*= 0*/) const
+uint32 Unit::CalculateDamage(WeaponAttackType attType, bool normalized, uint8 itemDamagesMask /*= 0*/) const
 {
     float minDamage = 0.0f;
     float maxDamage = 0.0f;
 
-    if (normalized || !addTotalPct || itemDamagesMask)
+    if (normalized || itemDamagesMask)
     {
         // get both by default
         if (!itemDamagesMask)
@@ -2430,7 +2440,7 @@ uint32 Unit::CalculateDamage(WeaponAttackType attType, bool normalized, bool add
             if (itemDamagesMask & (1 << i))
             {
                 float minTmp, maxTmp;
-                CalculateMinMaxDamage(attType, normalized, addTotalPct, minTmp, maxTmp, i);
+                CalculateMinMaxDamage(attType, normalized, minTmp, maxTmp, i);
                 minDamage += minTmp;
                 maxDamage += maxTmp;
             }
@@ -8365,28 +8375,6 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
     // Done total percent damage auras
     float DoneTotalMod = 1.0f;
 
-    // TODO: This was removed as we use the weapon's damage type in Spell::EffectWeaponDmg, which for all current weapons will apply
-    // the attack mod pct to the base weapon damage, and we don't want to apply it twice
-    // TODO: Add non-physical attack mod pct to the base weapon damage to support non-physical primary weapon flat/pct damage mods
-    // if (!(damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
-    // {
-    //     // Some spells don't benefit from pct done mods
-    //     if (!spellProto || !spellProto->HasAttribute(SPELL_ATTR6_LIMIT_PCT_DAMAGE_MODS))
-    //     {
-    //         float maxModDamagePercentSchool = 0.0f;
-    //         if (GetTypeId() == TYPEID_PLAYER)
-    //         {
-    //             for (uint32 i = SPELL_SCHOOL_HOLY; i < MAX_SPELL_SCHOOL; ++i)
-    //                 if (damageSchoolMask & (1 << i))
-    //                     maxModDamagePercentSchool = std::max(maxModDamagePercentSchool, GetFloatValue(PLAYER_FIELD_MOD_DAMAGE_DONE_PCT + i));
-    //         }
-    //         else
-    //             maxModDamagePercentSchool = GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE, damageSchoolMask);
-
-    //         DoneTotalMod *= maxModDamagePercentSchool;
-    //     }
-    // }
-
     DoneTotalMod *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_DONE_VERSUS, creatureTypeMask);
 
     // bonus against aurastate
@@ -9600,6 +9588,7 @@ bool Unit::HandleAttackPowerModifier(AttackPowerModIndex index, AttackPowerModTy
         return false;
     UpdateAttackPowerAndDamage(index == RANGED_AP_MODS);
 }
+
 float Unit::GetAttackPowerModifierValue(AttackPowerModIndex index, AttackPowerModType modifierType) const
 {
     if (index >= AP_MODS_COUNT || modifierType >= AP_MOD_TYPE_COUNT)
@@ -9618,6 +9607,7 @@ float Unit::GetAttackPowerModifierValue(AttackPowerModIndex index, AttackPowerMo
     }
     return 0;
 }
+
 void Unit::HandleStatFlatModifier(UnitMods unitMod, UnitModifierFlatType modifierType, float amount, bool apply)
 {
     if (unitMod >= UNIT_MOD_END || modifierType >= MODIFIER_TYPE_FLAT_END)
@@ -9638,6 +9628,23 @@ void Unit::HandleStatFlatModifier(UnitMods unitMod, UnitModifierFlatType modifie
         default:
             break;
     }
+
+    UpdateUnitMod(unitMod);
+}
+
+void Unit::HandleDamageFlatModifier(UnitMods unitMod, SpellSchools school, float amount, bool apply)
+{
+    uint32 unitModOffset = unitMod - UNIT_MOD_DAMAGE_MAINHAND;
+    if (school >= MAX_SPELL_SCHOOL || unitModOffset >= 2)
+    {
+        TC_LOG_ERROR("entities.unit", "ERROR in HandleDamageFlatModifier(): non-existing SpellSchools or wrong UnitModOffset!");
+        return;
+    }
+
+    if (!amount)
+        return;
+
+    m_auraDamageFlatModifiersGroup[unitModOffset][school] += apply ? amount : -amount;
 
     UpdateUnitMod(unitMod);
 }
@@ -9675,12 +9682,32 @@ void Unit::SetStatFlatModifier(UnitMods unitMod, UnitModifierFlatType modifierTy
     UpdateUnitMod(unitMod);
 }
 
+void Unit::SetDamageFlatModifier(UnitMods unitMod, SpellSchools school, float val)
+{
+    uint32 unitModOffset = unitMod - UNIT_MOD_DAMAGE_MAINHAND;
+    if (m_auraDamageFlatModifiersGroup[unitModOffset][school] == val)
+        return;
+
+    m_auraDamageFlatModifiersGroup[unitModOffset][school] = val;
+    UpdateUnitMod(unitMod);
+}
+
 void Unit::SetStatPctModifier(UnitMods unitMod, UnitModifierPctType modifierType, float val)
 {
     if (m_auraPctModifiersGroup[unitMod][modifierType] == val)
         return;
 
     m_auraPctModifiersGroup[unitMod][modifierType] = val;
+    UpdateUnitMod(unitMod);
+}
+
+void Unit::SetDamagePctModifier(UnitMods unitMod, SpellSchools school, float val)
+{
+    uint32 unitModOffset = unitMod - UNIT_MOD_DAMAGE_MAINHAND;
+    if (m_auraDamagePctModifiersGroup[unitModOffset][school] == val)
+        return;
+
+    m_auraDamagePctModifiersGroup[unitModOffset][school] = val;
     UpdateUnitMod(unitMod);
 }
 
@@ -9695,6 +9722,18 @@ float Unit::GetFlatModifierValue(UnitMods unitMod, UnitModifierFlatType modifier
     return m_auraFlatModifiersGroup[unitMod][modifierType];
 }
 
+float Unit::GetDamageFlatModifierValue(UnitMods unitMod, SpellSchools school) const
+{
+    uint32 unitModOffset = unitMod - UNIT_MOD_DAMAGE_MAINHAND;
+    if (unitModOffset >= 2 || school >= MAX_SPELL_SCHOOL)
+    {
+        TC_LOG_ERROR("entities.unit", "attempt to access non-existing modifier value from UnitMods!");
+        return 0.0f;
+    }
+
+    return m_auraDamageFlatModifiersGroup[unitModOffset][school];
+}
+
 float Unit::GetPctModifierValue(UnitMods unitMod, UnitModifierPctType modifierType) const
 {
     if (unitMod >= UNIT_MOD_END || modifierType >= MODIFIER_TYPE_PCT_END)
@@ -9704,6 +9743,18 @@ float Unit::GetPctModifierValue(UnitMods unitMod, UnitModifierPctType modifierTy
     }
 
     return m_auraPctModifiersGroup[unitMod][modifierType];
+}
+
+float Unit::GetDamagePctModifierValue(UnitMods unitMod, SpellSchools school) const
+{
+    uint32 unitModOffset = unitMod - UNIT_MOD_DAMAGE_MAINHAND;
+    if (unitModOffset >= 2 || school >= MAX_SPELL_SCHOOL)
+    {
+        TC_LOG_ERROR("entities.unit", "attempt to access non-existing modifier value from UnitMods!");
+        return 0.0f;
+    }
+
+    return m_auraDamagePctModifiersGroup[unitModOffset][school];
 }
 
 void Unit::UpdateUnitMod(UnitMods unitMod)
@@ -9765,15 +9816,21 @@ void Unit::UpdateDamageDoneMods(WeaponAttackType attackType, int32 /*skipEnchant
             break;
     }
 
-    float amount = GetTotalAuraModifier(SPELL_AURA_MOD_DAMAGE_DONE, [&](AuraEffect const* aurEff) -> bool
+    for (uint8 school = SPELL_SCHOOL_NORMAL; school < MAX_SPELL_SCHOOL; ++school)
     {
-        if (!(aurEff->GetMiscValue() & SPELL_SCHOOL_MASK_NORMAL))
-            return false;
+        float amount = GetTotalAuraModifier(SPELL_AURA_MOD_DAMAGE_DONE, [&](AuraEffect const* aurEff) -> bool
+        {
+            if (!(aurEff->GetMiscValue() & (1 << school)))
+                return false;
 
-        return CheckAttackFitToAuraRequirement(attackType, aurEff);
-    });
+            return CheckAttackFitToAuraRequirement(attackType, aurEff);
+        });
 
-    SetStatFlatModifier(unitMod, TOTAL_VALUE, amount);
+        SetDamageFlatModifier(unitMod, SpellSchools(school), amount);
+        // Set the normal mod here as well
+        if (school == SPELL_SCHOOL_NORMAL)
+            SetStatFlatModifier(unitMod, TOTAL_VALUE, amount);
+    }
 }
 
 void Unit::UpdateAllDamageDoneMods()
@@ -9806,18 +9863,25 @@ void Unit::UpdateDamagePctDoneMods(WeaponAttackType attackType)
             break;
     }
 
-    factor *= GetTotalAuraMultiplier(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE, [attackType, this](AuraEffect const* aurEff) -> bool
+    for (uint8 school = SPELL_SCHOOL_NORMAL; school < MAX_SPELL_SCHOOL; ++school)
     {
-        if (!(aurEff->GetMiscValue() & SPELL_SCHOOL_MASK_NORMAL))
-            return false;
+        float schoolFactor = factor;
+        schoolFactor *= GetTotalAuraMultiplier(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE, [attackType, school, this](AuraEffect const* aurEff) -> bool
+        {
+            if (!(aurEff->GetMiscValue() & (1 << school)))
+                return false;
 
-        return CheckAttackFitToAuraRequirement(attackType, aurEff);
-    });
+            return CheckAttackFitToAuraRequirement(attackType, aurEff);
+        });
 
-    if (attackType == OFF_ATTACK)
-        factor *= GetTotalAuraMultiplier(SPELL_AURA_MOD_OFFHAND_DAMAGE_PCT, std::bind(&Unit::CheckAttackFitToAuraRequirement, this, attackType, std::placeholders::_1));
+        if (attackType == OFF_ATTACK)
+            schoolFactor *= GetTotalAuraMultiplier(SPELL_AURA_MOD_OFFHAND_DAMAGE_PCT, std::bind(&Unit::CheckAttackFitToAuraRequirement, this, attackType, std::placeholders::_1));
 
-    SetStatPctModifier(unitMod, TOTAL_PCT, factor);
+        SetDamagePctModifier(unitMod, SpellSchools(school), schoolFactor);
+        // Set the normal mod here as well
+        if (school == SPELL_SCHOOL_NORMAL)
+            SetStatPctModifier(unitMod, TOTAL_PCT, schoolFactor);
+    }
 }
 
 void Unit::UpdateAllDamagePctDoneMods()

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1186,7 +1186,7 @@ void Unit::DealSpellDamage(SpellNonMeleeDamage const* damageInfo, bool durabilit
     Unit::DealDamage(this, victim, damageInfo->damage, &cleanDamage, SPELL_DIRECT_DAMAGE, SpellSchoolMask(damageInfo->schoolMask), spellProto, durabilityLoss);
 }
 
-/// @todo for melee need create structure as in
+// Builds CalcDamageInfo for melee auto attack
 void Unit::CalculateMeleeDamage(Unit* victim, CalcDamageInfo* damageInfo, WeaponAttackType attackType)
 {
     damageInfo->Attacker         = this;
@@ -1256,11 +1256,13 @@ void Unit::CalculateMeleeDamage(Unit* victim, CalcDamageInfo* damageInfo, Weapon
             continue;
 
         SpellSchoolMask schoolMask = SpellSchoolMask(damageInfo->Damages[i].DamageSchoolMask);
+
         bool const addPctMods = (schoolMask & SPELL_SCHOOL_MASK_NORMAL);
 
-        uint32 damage = 0;
         uint8 itemDamagesMask = (GetTypeId() == TYPEID_PLAYER) ? (1 << i) : 0;
-        damage += CalculateDamage(damageInfo->AttackType, false, addPctMods, itemDamagesMask);
+
+        uint32 damage = CalculateDamage(damageInfo->AttackType, false, addPctMods, itemDamagesMask);
+
         // Add melee damage bonus
         damage = MeleeDamageBonusDone(damageInfo->Target, damage, damageInfo->AttackType, nullptr, schoolMask);
         damage = damageInfo->Target->MeleeDamageBonusTaken(this, damage, damageInfo->AttackType, nullptr, schoolMask);
@@ -2179,6 +2181,7 @@ void Unit::HandleEmoteCommand(Emote emoteId)
         healInfo.AbsorbHeal(absorbAmount);
 }
 
+// Attempts to perform a melee auto attack on the given victim
 void Unit::AttackerStateUpdate(Unit* victim, WeaponAttackType attType, bool extra)
 {
     if (HasUnitFlag(UNIT_FLAG_PACIFIED))
@@ -2202,39 +2205,43 @@ void Unit::AttackerStateUpdate(Unit* victim, WeaponAttackType attType, bool extr
     if (!extra && _lastExtraAttackSpell)
         _lastExtraAttackSpell = 0;
 
-    // melee attack spell cast at main hand attack only - no normal melee dmg dealt
+    // attempt to cast when CURRENT_MELEE_SPELL is set, if unsuccessful continue with auto attack
     if (attType == BASE_ATTACK && m_currentSpells[CURRENT_MELEE_SPELL] && !extra)
     {
-        m_currentSpells[CURRENT_MELEE_SPELL]->cast();
         Spell* spell = m_currentSpells[CURRENT_MELEE_SPELL];
-        if (!spell || !spell->m_spellInfo->IsNextMeleeSwingSpell() || spell->isSuccessCast())
+        spell->cast();
+        if (spell->isSuccessCast())
             return;
     }
 
-        // attack can be redirected to another target
-        victim = GetMeleeHitRedirectTarget(victim);
+    // attack can be redirected to another target
+    victim = GetMeleeHitRedirectTarget(victim);
 
-        CalcDamageInfo damageInfo;
-        CalculateMeleeDamage(victim, &damageInfo, attType);
-        // Send log damage message to client
+    // This is the struct we build out for the client to update the attack state
+    CalcDamageInfo damageInfo;
+    // Build out the struct with all the damage info
+    CalculateMeleeDamage(victim, &damageInfo, attType);
 
-        for (uint8 i = 0; i < MAX_ITEM_PROTO_DAMAGES; ++i)
-            Unit::DealDamageMods(victim, damageInfo.Damages[i].Damage, &damageInfo.Damages[i].Absorb);
-        SendAttackStateUpdate(&damageInfo);
+    // Last step to negate damage for no victim, dead victim, in flight, or evading - adds to absorb totals
+    for (uint8 i = 0; i < MAX_ITEM_PROTO_DAMAGES; ++i)
+        Unit::DealDamageMods(victim, damageInfo.Damages[i].Damage, &damageInfo.Damages[i].Absorb);
 
-        _lastDamagedTargetGuid = victim->GetGUID();
+    SendAttackStateUpdate(&damageInfo);
 
-        DealMeleeDamage(&damageInfo, true);
+    _lastDamagedTargetGuid = victim->GetGUID();
 
-        DamageInfo dmgInfo(damageInfo);
-        Unit::ProcSkillsAndAuras(damageInfo.Attacker, damageInfo.Target, damageInfo.ProcAttacker, damageInfo.ProcVictim, PROC_SPELL_TYPE_NONE, PROC_SPELL_PHASE_NONE, dmgInfo.GetHitMask(), nullptr, &dmgInfo, nullptr);
+    // Apply the damage
+    DealMeleeDamage(&damageInfo, true);
 
-        if (GetTypeId() == TYPEID_PLAYER)
-            TC_LOG_DEBUG("entities.unit", "AttackerStateUpdate: (Player) {} attacked {} for {} dmg, absorbed {}, blocked {}, resisted {}.",
-                GetGUID().ToString(), victim->GetGUID().ToString(), dmgInfo.GetDamage(), dmgInfo.GetAbsorb(), dmgInfo.GetBlock(), dmgInfo.GetResist());
-        else
-            TC_LOG_DEBUG("entities.unit", "AttackerStateUpdate: (NPC)    {} attacked {} for {} dmg, absorbed {}, blocked {}, resisted {}.",
-                GetGUID().ToString(), victim->GetGUID().ToString(), dmgInfo.GetDamage(), dmgInfo.GetAbsorb(), dmgInfo.GetBlock(), dmgInfo.GetResist());
+    DamageInfo dmgInfo(damageInfo);
+    Unit::ProcSkillsAndAuras(damageInfo.Attacker, damageInfo.Target, damageInfo.ProcAttacker, damageInfo.ProcVictim, PROC_SPELL_TYPE_NONE, PROC_SPELL_PHASE_NONE, dmgInfo.GetHitMask(), nullptr, &dmgInfo, nullptr);
+
+    if (GetTypeId() == TYPEID_PLAYER)
+        TC_LOG_DEBUG("entities.unit", "AttackerStateUpdate: (Player) {} attacked {} for {} dmg, absorbed {}, blocked {}, resisted {}.",
+            GetGUID().ToString(), victim->GetGUID().ToString(), dmgInfo.GetDamage(), dmgInfo.GetAbsorb(), dmgInfo.GetBlock(), dmgInfo.GetResist());
+    else
+        TC_LOG_DEBUG("entities.unit", "AttackerStateUpdate: (NPC)    {} attacked {} for {} dmg, absorbed {}, blocked {}, resisted {}.",
+            GetGUID().ToString(), victim->GetGUID().ToString(), dmgInfo.GetDamage(), dmgInfo.GetAbsorb(), dmgInfo.GetBlock(), dmgInfo.GetResist());
 }
 
 void Unit::HandleProcExtraAttackFor(Unit* victim, uint32 count)
@@ -3331,16 +3338,6 @@ void Unit::FinishSpell(CurrentSpellTypes spellType, bool ok /*= true*/)
 
     spell->finish(ok);
 }
-
-/** @epoch-start */
-bool Unit::IsNextSwingSpellCasted() const
-{
-    if (m_currentSpells[CURRENT_MELEE_SPELL] && m_currentSpells[CURRENT_MELEE_SPELL]->m_spellInfo->IsNextMeleeSwingSpell())
-        return (true);
-
-    return (false);
-}
-/** @epoch-end */
 
 bool Unit::IsNonMeleeSpellCast(bool withDelayed, bool skipChanneled, bool skipAutorepeat, bool isAutoshoot, bool skipInstant) const
 {
@@ -8299,6 +8296,8 @@ bool Unit::IsImmunedToSpellEffect(SpellInfo const* spellInfo, SpellEffectInfo co
     return false;
 }
 
+// Calculate the melee damage bonus for AutoAttack Unit::CalculateMeleeDamage
+// TODO come back and remove spellProto and all logic pertaining to it if we decide we will no longer call this from Spell::EffectWeaponDmg
 uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType attType, SpellInfo const* spellProto /*= nullptr*/, SpellSchoolMask damageSchoolMask /*= SPELL_SCHOOL_MASK_NORMAL*/)
 {
     if (!victim || pdamage == 0)
@@ -8342,22 +8341,8 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
     // Done total percent damage auras
     float DoneTotalMod = 1.0f;
 
-    SpellSchoolMask schoolMask = spellProto ? spellProto->GetSchoolMask() : damageSchoolMask;
-
-    /** @epoch-start */
-    // for wands, use the weapon damage type instead of the shooting spell school
-    // TODO: look into this, this seems odd?
-    if (spellProto)
-    {
-        if (spellProto->EquippedItemSubClassMask == (1 << ITEM_SUBCLASS_WEAPON_WAND))
-        {
-            schoolMask = damageSchoolMask;
-        }
-    }
-    /** @epoch-end */
-
     // mods for SPELL_SCHOOL_MASK_NORMAL are already factored in base melee damage calculation
-    if (!(schoolMask & SPELL_SCHOOL_MASK_NORMAL))
+    if (!(damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
     {
         // Some spells don't benefit from pct done mods
         if (!spellProto || !spellProto->HasAttribute(SPELL_ATTR6_LIMIT_PCT_DAMAGE_MODS))
@@ -8366,11 +8351,11 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
             if (GetTypeId() == TYPEID_PLAYER)
             {
                 for (uint32 i = SPELL_SCHOOL_HOLY; i < MAX_SPELL_SCHOOL; ++i)
-                    if (schoolMask & (1 << i))
+                    if (damageSchoolMask & (1 << i))
                         maxModDamagePercentSchool = std::max(maxModDamagePercentSchool, GetFloatValue(PLAYER_FIELD_MOD_DAMAGE_DONE_PCT + i));
             }
             else
-                maxModDamagePercentSchool = GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE, schoolMask);
+                maxModDamagePercentSchool = GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE, damageSchoolMask);
 
             DoneTotalMod *= maxModDamagePercentSchool;
         }
@@ -8469,14 +8454,13 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
     return uint32(std::max(tmpDamage, 0.0f));
 }
 
+// Calculates the MeleeDamageBonusTaken for Auto Attacks (school mask is taken from the weapon proto)
 uint32 Unit::MeleeDamageBonusTaken(Unit* attacker, uint32 pdamage, WeaponAttackType attType, SpellInfo const* spellProto /*= nullptr*/, SpellSchoolMask damageSchoolMask /*= SPELL_SCHOOL_MASK_NORMAL*/)
 {
     if (pdamage == 0)
         return 0;
 
     int32 TakenFlatBenefit = 0;
-
-    uint32 meleeDamageSchoolMask = spellProto ? spellProto->SchoolMask : attacker->GetMeleeDamageSchoolMask();
 
     // ..taken
     /** @epoch-start */

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9594,6 +9594,8 @@ void Unit::HandleDamageFlatModifier(UnitMods unitMod, SpellSchools school, float
         return;
     }
 
+    TC_LOG_DEBUG("damagetypes", "Unit::HandleDamageFlatModifier: {} {} {} {}", unitMod, school, amount, apply);
+
     if (!amount)
         return;
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9725,7 +9725,7 @@ float Unit::GetFlatModifierValue(UnitMods unitMod, UnitModifierFlatType modifier
 float Unit::GetDamageFlatModifierValue(UnitMods unitMod, SpellSchools school) const
 {
     uint32 unitModOffset = unitMod - UNIT_MOD_DAMAGE_MAINHAND;
-    if (unitModOffset >= 2 || school >= MAX_SPELL_SCHOOL)
+    if (unitModOffset >= 3 || school >= MAX_SPELL_SCHOOL)
     {
         TC_LOG_ERROR("entities.unit", "attempt to access non-existing modifier value from UnitMods!");
         return 0.0f;
@@ -9748,7 +9748,7 @@ float Unit::GetPctModifierValue(UnitMods unitMod, UnitModifierPctType modifierTy
 float Unit::GetDamagePctModifierValue(UnitMods unitMod, SpellSchools school) const
 {
     uint32 unitModOffset = unitMod - UNIT_MOD_DAMAGE_MAINHAND;
-    if (unitModOffset >= 2 || school >= MAX_SPELL_SCHOOL)
+    if (unitModOffset >= 3 || school >= MAX_SPELL_SCHOOL)
     {
         TC_LOG_ERROR("entities.unit", "attempt to access non-existing modifier value from UnitMods!");
         return 0.0f;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8365,10 +8365,9 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
     // Done total percent damage auras
     float DoneTotalMod = 1.0f;
 
-    // TODO: This was removed as we use the weapon's damage type in Spell::EffectWeaponDmg which should account for these
-    // We can remove this when its stable
-    // TODO: Add non-physical attack mod pct to support non-physical primary weapon damage
-    // mods for SPELL_SCHOOL_MASK_NORMAL are already factored in base melee damage calculation
+    // TODO: This was removed as we use the weapon's damage type in Spell::EffectWeaponDmg, which for all current weapons will apply
+    // the attack mod pct to the base weapon damage, and we don't want to apply it twice
+    // TODO: Add non-physical attack mod pct to the base weapon damage to support non-physical primary weapon flat/pct damage mods
     // if (!(damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
     // {
     //     // Some spells don't benefit from pct done mods

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1562,9 +1562,6 @@ class TC_GAME_API Unit : public WorldObject
         // delayed+channeled spells are always accounted as cast
         // we can skip channeled or delayed checks using flags
         bool IsNonMeleeSpellCast(bool withDelayed, bool skipChanneled = false, bool skipAutorepeat = false, bool isAutoshoot = false, bool skipInstant = true) const;
-        /** @epoch-start */
-        bool IsNextSwingSpellCasted() const;
-        /** @epoch-end */
 
         // set withDelayed to true to interrupt delayed spells too
         // delayed+channeled spells are always interrupted

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -926,6 +926,7 @@ class TC_GAME_API Unit : public WorldObject
         bool IsWithinMeleeRangeAt(Position const& pos, Unit const* obj) const;
         float GetMeleeRange(Unit const* target) const;
         virtual SpellSchoolMask GetMeleeDamageSchoolMask(WeaponAttackType attackType = BASE_ATTACK, uint8 damageIndex = 0) const = 0;
+        virtual SpellSchools GetMeleeDamageSchool(WeaponAttackType attackType = BASE_ATTACK, uint8 damageIndex = 0) const = 0;
         bool m_canDualWield;
 
         void _addAttacker(Unit* pAttacker);                  // must be called only from Unit::Attack(Unit*)

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -20,6 +20,7 @@
 
 #include "Object.h"
 #include "CombatManager.h"
+#include "SharedDefines.h"
 #include "SpellAuraDefines.h"
 #include "ThreatManager.h"
 #include "Timer.h"
@@ -1599,13 +1600,18 @@ class TC_GAME_API Unit : public WorldObject
 
         // stat system
         void HandleStatFlatModifier(UnitMods unitMod, UnitModifierFlatType modifierType, float amount, bool apply);
+        void HandleDamageFlatModifier(UnitMods unitMod, SpellSchools school, float amount, bool apply);
         void ApplyStatPctModifier(UnitMods unitMod, UnitModifierPctType modifierType, float amount);
 
         void SetStatFlatModifier(UnitMods unitMod, UnitModifierFlatType modifierType, float val);
+        void SetDamageFlatModifier(UnitMods unitMod, SpellSchools school, float val);
         void SetStatPctModifier(UnitMods unitMod, UnitModifierPctType modifierType, float val);
+        void SetDamagePctModifier(UnitMods unitMod, SpellSchools school, float val);
 
         float GetFlatModifierValue(UnitMods unitMod, UnitModifierFlatType modifierType) const;
+        float GetDamageFlatModifierValue(UnitMods unitMod, SpellSchools school) const;
         float GetPctModifierValue(UnitMods unitMod, UnitModifierPctType modifierType) const;
+        float GetDamagePctModifierValue(UnitMods unitMod, SpellSchools school) const;
 
         bool HandleAttackPowerModifier(AttackPowerModIndex index, AttackPowerModType modifierType, float amount, bool apply);
         float GetAttackPowerModifierValue(AttackPowerModIndex index, AttackPowerModType modifierType) const;
@@ -1648,8 +1654,8 @@ class TC_GAME_API Unit : public WorldObject
         float GetTotalAttackPowerValue(WeaponAttackType attType) const;
         float GetWeaponDamageRange(WeaponAttackType attType, WeaponDamageRange type, uint8 damageIndex = 0) const;
         void SetBaseWeaponDamage(WeaponAttackType attType, WeaponDamageRange damageRange, float value, uint8 damageIndex = 0) { m_weaponDamage[attType][damageRange][damageIndex] = value; }
-        virtual void CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, bool addTotalPct, float& minDamage, float& maxDamage, uint8 damageIndex) const = 0;
-        uint32 CalculateDamage(WeaponAttackType attType, bool normalized, bool addTotalPct, uint8 itemDamagesMask = 0) const;
+        virtual void CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, float& minDamage, float& maxDamage, uint8 damageIndex) const = 0;
+        uint32 CalculateDamage(WeaponAttackType attType, bool normalized, uint8 itemDamagesMask = 0) const;
         float GetAPMultiplier(WeaponAttackType attType, bool normalized) const;
 
         bool isInFrontInMap(Unit const* target, float distance, float arc = float(M_PI)) const;
@@ -1980,7 +1986,9 @@ class TC_GAME_API Unit : public WorldObject
         uint32 m_interruptMask;
 
         float m_auraFlatModifiersGroup[UNIT_MOD_END][MODIFIER_TYPE_FLAT_END];
+        float m_auraDamageFlatModifiersGroup[3][MAX_SPELL_SCHOOL];
         float m_auraPctModifiersGroup[UNIT_MOD_END][MODIFIER_TYPE_PCT_END];
+        float m_auraDamagePctModifiersGroup[3][MAX_SPELL_SCHOOL];
         AttackPowerModInfo m_attackPowerMods[AP_MODS_COUNT]; // Handle both flat + pct
         float m_weaponDamage[MAX_ATTACK][2][2];
         bool m_canModifyStats;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1719,7 +1719,7 @@ class TC_GAME_API Unit : public WorldObject
         int32 SpellBaseDamageBonusDone(SpellSchoolMask schoolMask) const;
         uint32 SpellDamageBonusDone(Unit* victim, SpellInfo const* spellProto, uint32 pdamage, DamageEffectType damagetype, uint32 totalTicks, SpellEffectInfo const& spellEffectInfo, Optional<float> const& donePctTotal, uint32 stack = 1) const;
         float SpellDamagePctDone(Unit* victim, SpellInfo const* spellProto, DamageEffectType damagetype) const;
-        uint32 SpellDamageBonusTaken(Unit* caster, SpellInfo const* spellProto, uint32 pdamage, DamageEffectType damagetype) const;
+        uint32 SpellDamageBonusTaken(Unit* caster, SpellInfo const* spellProto, uint32 pdamage, DamageEffectType damagetype, uint32 totalTicks, SpellEffectInfo const& spellEffectInfo, uint32 stack = 1) const;
         int32 SpellBaseHealingBonusDone(SpellSchoolMask schoolMask) const;
         uint32 SpellHealingBonusDone(Unit* victim, SpellInfo const* spellProto, uint32 healamount, DamageEffectType damagetype, uint32 totalTicks, SpellEffectInfo const& spellEffectInfo, Optional<float> const& donePctTotal, uint32 stack = 1) const;
         float SpellHealingPctDone(Unit* victim, SpellInfo const* spellProto) const;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1716,9 +1716,9 @@ class TC_GAME_API Unit : public WorldObject
         Unit* GetMeleeHitRedirectTarget(Unit* victim, SpellInfo const* spellInfo = nullptr);
 
         int32 SpellBaseDamageBonusDone(SpellSchoolMask schoolMask) const;
-        uint32 SpellDamageBonusDone(Unit* victim, SpellInfo const* spellProto, SpellSchoolMask schoolMask, uint32 pdamage, DamageEffectType damagetype, uint32 totalTicks, SpellEffectInfo const& spellEffectInfo, Optional<float> const& donePctTotal, uint32 stack = 1) const;
-        float SpellDamagePctDone(Unit* victim, SpellInfo const* spellProto, SpellSchoolMask schoolMask, DamageEffectType damagetype) const;
-        uint32 SpellDamageBonusTaken(Unit* caster, SpellInfo const* spellProto, SpellSchoolMask schoolMask, uint32 pdamage, DamageEffectType damagetype) const;
+        uint32 SpellDamageBonusDone(Unit* victim, SpellInfo const* spellProto, uint32 pdamage, DamageEffectType damagetype, uint32 totalTicks, SpellEffectInfo const& spellEffectInfo, Optional<float> const& donePctTotal, uint32 stack = 1) const;
+        float SpellDamagePctDone(Unit* victim, SpellInfo const* spellProto, DamageEffectType damagetype) const;
+        uint32 SpellDamageBonusTaken(Unit* caster, SpellInfo const* spellProto, uint32 pdamage, DamageEffectType damagetype) const;
         int32 SpellBaseHealingBonusDone(SpellSchoolMask schoolMask) const;
         uint32 SpellHealingBonusDone(Unit* victim, SpellInfo const* spellProto, uint32 healamount, DamageEffectType damagetype, uint32 totalTicks, SpellEffectInfo const& spellEffectInfo, Optional<float> const& donePctTotal, uint32 stack = 1) const;
         float SpellHealingPctDone(Unit* victim, SpellInfo const* spellProto) const;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1746,7 +1746,7 @@ class TC_GAME_API Unit : public WorldObject
         uint32 GetMechanicImmunityMask() const;
 
         bool IsImmunedToDamage(SpellSchoolMask meleeSchoolMask) const;
-        bool IsImmunedToDamage(SpellInfo const* spellInfo) const;
+        bool IsImmunedToDamage(SpellInfo const* spellInfo, SpellSchoolMask damageSchoolMask = SPELL_SCHOOL_MASK_NONE) const;
         virtual bool IsImmunedToSpellEffect(SpellInfo const* spellInfo, SpellEffectInfo const& spellEffectInfo, WorldObject const* caster, bool requireImmunityPurgesEffectAttribute = false) const;
 
         static bool IsDamageReducedByArmor(SpellSchoolMask damageSchoolMask, SpellInfo const* spellInfo = nullptr);

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1724,7 +1724,7 @@ class TC_GAME_API Unit : public WorldObject
         float SpellHealingPctDone(Unit* victim, SpellInfo const* spellProto) const;
         uint32 SpellHealingBonusTaken(Unit* caster, SpellInfo const* spellProto, uint32 healamount, DamageEffectType damagetype) const;
 
-        uint32 MeleeDamageBonusDone(Unit* pVictim, uint32 damage, WeaponAttackType attType, SpellInfo const* spellProto = nullptr, SpellSchoolMask damageSchoolMask = SPELL_SCHOOL_MASK_NORMAL);
+        uint32 MeleeDamageBonusDone(Unit* pVictim, uint32 damage, WeaponAttackType attType, SpellInfo const* spellProto = nullptr);
         uint32 MeleeDamageBonusTaken(Unit* attacker, uint32 pdamage, WeaponAttackType attType, SpellInfo const* spellProto = nullptr, SpellSchoolMask damageSchoolMask = SPELL_SCHOOL_MASK_NORMAL);
 
         bool IsBlockCritical();

--- a/src/server/game/Handlers/SpellHandler.cpp
+++ b/src/server/game/Handlers/SpellHandler.cpp
@@ -503,7 +503,7 @@ void WorldSession::HandleCancelCastOpcode(WorldPackets::Spells::CancelCast& canc
         _player->InterruptNonMeleeSpells(false, cancelCast.SpellID, false);
 
     /** @epoch-start */
-    if (_player->IsNextSwingSpellCasted())
+    if (_player->GetCurrentSpell(CURRENT_MELEE_SPELL))
         _player->InterruptSpell(CURRENT_MELEE_SPELL);
     /** @epoch-end */
 }

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -4252,8 +4252,7 @@ void AuraEffect::HandleModDamageDone(AuraApplication const* aurApp, uint8 mode, 
 
     Unit* target = aurApp->GetTarget();
 
-    if (GetMiscValue() & SPELL_SCHOOL_MASK_NORMAL)
-        target->UpdateAllDamageDoneMods();
+    target->UpdateAllDamageDoneMods();
 
     // Magic damage modifiers implemented in Unit::SpellBaseDamageBonusDone
     // This information for client side use only
@@ -4277,8 +4276,7 @@ void AuraEffect::HandleModDamagePercentDone(AuraApplication const* aurApp, uint8
     Unit* target = aurApp->GetTarget();
 
     // also handles spell group stacks
-    if (GetMiscValue() & SPELL_SCHOOL_MASK_NORMAL)
-        target->UpdateAllDamagePctDoneMods();
+    target->UpdateAllDamagePctDoneMods();
 
     // similar to the above, damage percent will be calculated on the fly in Unit::SpellDamageBonusDone
     // This is so that we can check that the spell used is eligible for the aura (wand specialization)

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5229,7 +5229,7 @@ void AuraEffect::HandlePeriodicDamageAurasTick(Unit* target, Unit* caster) const
     else // ceil obtained value, it may happen that 10 ticks for 10% damage may not kill owner
         damage = uint32(ceil(CalculatePct<float, float>(target->GetMaxHealth(), damage)));
 
-    damage = target->SpellDamageBonusTaken(caster, GetSpellInfo(), damage, DOT);
+    damage = target->SpellDamageBonusTaken(caster, GetSpellInfo(), damage, DOT, GetTotalTicks(), GetSpellEffectInfo(), GetBase()->GetStackAmount());
 
     // @tswow-begin
     float crit_chance = GetCritChanceFor(caster,target);
@@ -5331,7 +5331,7 @@ void AuraEffect::HandlePeriodicHealthLeechAuraTick(Unit* target, Unit* caster) c
     // dynobj auras must always have a caster
     if (GetBase()->GetType() == DYNOBJ_AURA_TYPE)
         damage = ASSERT_NOTNULL(caster)->SpellDamageBonusDone(target, GetSpellInfo(), damage, DOT, GetTotalTicks(), GetSpellEffectInfo(), { }, GetBase()->GetStackAmount());
-    damage = target->SpellDamageBonusTaken(caster, GetSpellInfo(), damage, DOT);
+    damage = target->SpellDamageBonusTaken(caster, GetSpellInfo(), damage, DOT, GetTotalTicks(), GetSpellEffectInfo(), GetBase()->GetStackAmount());
 
     // @tswow-begin
     float crit_chance = GetCritChanceFor(caster,target);
@@ -5793,7 +5793,7 @@ void AuraEffect::HandleProcTriggerDamageAuraProc(AuraApplication* aurApp, ProcEv
 
     SpellNonMeleeDamage damageInfo(target, triggerTarget, GetId(), GetSpellInfo()->SchoolMask);
     uint32 damage = target->SpellDamageBonusDone(triggerTarget, GetSpellInfo(), GetAmount(), SPELL_DIRECT_DAMAGE, 1, GetSpellEffectInfo(), { });
-    damage = triggerTarget->SpellDamageBonusTaken(target, GetSpellInfo(), damage, SPELL_DIRECT_DAMAGE);
+    damage = triggerTarget->SpellDamageBonusTaken(target, GetSpellInfo(), damage, SPELL_DIRECT_DAMAGE, 1, GetSpellEffectInfo());
     // @tswow-begin effect mask
     target->CalculateSpellDamageTaken(&damageInfo, damage, GetSpellInfo(), BASE_ATTACK, false, false, nullptr, 1 << GetSpellEffectInfo().EffectIndex);
     // @tswow-end

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -4252,7 +4252,9 @@ void AuraEffect::HandleModDamageDone(AuraApplication const* aurApp, uint8 mode, 
 
     Unit* target = aurApp->GetTarget();
 
-    target->UpdateAllDamageDoneMods();
+    // for now flat mods do not modify elemental weapon damage, remove this 'if' if we support it in the future
+    if (GetMiscValue() & SPELL_SCHOOL_MASK_NORMAL)
+        target->UpdateAllDamageDoneMods();
 
     // Magic damage modifiers implemented in Unit::SpellBaseDamageBonusDone
     // This information for client side use only

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -513,7 +513,7 @@ int32 AuraEffect::CalculateAmount(Unit* caster)
             case SPELL_AURA_PERIODIC_DAMAGE:
             case SPELL_AURA_PERIODIC_LEECH:
                 if (GetBase()->GetType() == UNIT_AURA_TYPE)
-                    amount = caster->SpellDamageBonusDone(GetBase()->GetUnitOwner(), GetSpellInfo(), GetSpellInfo()->GetSchoolMask(), amount, DOT, GetTotalTicks(), GetSpellEffectInfo(), GetBase()->GetDonePct());
+                    amount = caster->SpellDamageBonusDone(GetBase()->GetUnitOwner(), GetSpellInfo(), amount, DOT, GetTotalTicks(), GetSpellEffectInfo(), GetBase()->GetDonePct());
                 break;
             case SPELL_AURA_PERIODIC_HEAL:
                 if (GetBase()->GetType() == UNIT_AURA_TYPE)
@@ -5203,7 +5203,7 @@ void AuraEffect::HandlePeriodicDamageAurasTick(Unit* target, Unit* caster) const
     {
         // leave only target depending bonuses, rest is handled in calculate amount
         if (GetBase()->GetType() == DYNOBJ_AURA_TYPE)
-            damage = caster->SpellDamageBonusDone(target, GetSpellInfo(), GetSpellInfo()->GetSchoolMask(), damage, DOT, GetTotalTicks(), GetSpellEffectInfo(), { }, GetBase()->GetStackAmount());
+            damage = caster->SpellDamageBonusDone(target, GetSpellInfo(), damage, DOT, GetTotalTicks(), GetSpellEffectInfo(), { }, GetBase()->GetStackAmount());
 
         switch (GetSpellInfo()->SpellFamilyName)
         {
@@ -5229,7 +5229,7 @@ void AuraEffect::HandlePeriodicDamageAurasTick(Unit* target, Unit* caster) const
     else // ceil obtained value, it may happen that 10 ticks for 10% damage may not kill owner
         damage = uint32(ceil(CalculatePct<float, float>(target->GetMaxHealth(), damage)));
 
-    damage = target->SpellDamageBonusTaken(caster, GetSpellInfo(), GetSpellInfo()->GetSchoolMask(), damage, DOT);
+    damage = target->SpellDamageBonusTaken(caster, GetSpellInfo(), damage, DOT);
 
     // @tswow-begin
     float crit_chance = GetCritChanceFor(caster,target);
@@ -5330,8 +5330,8 @@ void AuraEffect::HandlePeriodicHealthLeechAuraTick(Unit* target, Unit* caster) c
 
     // dynobj auras must always have a caster
     if (GetBase()->GetType() == DYNOBJ_AURA_TYPE)
-        damage = ASSERT_NOTNULL(caster)->SpellDamageBonusDone(target, GetSpellInfo(), GetSpellInfo()->GetSchoolMask(), damage, DOT, GetTotalTicks(), GetSpellEffectInfo(), { }, GetBase()->GetStackAmount());
-    damage = target->SpellDamageBonusTaken(caster, GetSpellInfo(), GetSpellInfo()->GetSchoolMask(), damage, DOT);
+        damage = ASSERT_NOTNULL(caster)->SpellDamageBonusDone(target, GetSpellInfo(), damage, DOT, GetTotalTicks(), GetSpellEffectInfo(), { }, GetBase()->GetStackAmount());
+    damage = target->SpellDamageBonusTaken(caster, GetSpellInfo(), damage, DOT);
 
     // @tswow-begin
     float crit_chance = GetCritChanceFor(caster,target);
@@ -5792,8 +5792,8 @@ void AuraEffect::HandleProcTriggerDamageAuraProc(AuraApplication* aurApp, ProcEv
     }
 
     SpellNonMeleeDamage damageInfo(target, triggerTarget, GetId(), GetSpellInfo()->SchoolMask);
-    uint32 damage = target->SpellDamageBonusDone(triggerTarget, GetSpellInfo(), GetSpellInfo()->GetSchoolMask(), GetAmount(), SPELL_DIRECT_DAMAGE, 1, GetSpellEffectInfo(), { });
-    damage = triggerTarget->SpellDamageBonusTaken(target, GetSpellInfo(), GetSpellInfo()->GetSchoolMask(), damage, SPELL_DIRECT_DAMAGE);
+    uint32 damage = target->SpellDamageBonusDone(triggerTarget, GetSpellInfo(), GetAmount(), SPELL_DIRECT_DAMAGE, 1, GetSpellEffectInfo(), { });
+    damage = triggerTarget->SpellDamageBonusTaken(target, GetSpellInfo(), damage, SPELL_DIRECT_DAMAGE);
     // @tswow-begin effect mask
     target->CalculateSpellDamageTaken(&damageInfo, damage, GetSpellInfo(), BASE_ATTACK, false, false, nullptr, 1 << GetSpellEffectInfo().EffectIndex);
     // @tswow-end

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -514,7 +514,7 @@ void Aura::SaveCasterInfo(Unit* caster)
                     break;
                 case SPELL_AURA_PERIODIC_DAMAGE:
                 case SPELL_AURA_PERIODIC_LEECH:
-                    _casterInfo.BonusDonePct = caster->SpellDamagePctDone(GetUnitOwner(), GetSpellInfo(), GetSpellInfo()->GetSchoolMask(), DOT);
+                    _casterInfo.BonusDonePct = caster->SpellDamagePctDone(GetUnitOwner(), GetSpellInfo(), DOT);
                     break;
                 default:
                     break;
@@ -1435,7 +1435,7 @@ void Aura::HandleAuraSpecificMods(AuraApplication const* aurApp, Unit* caster, b
                     if (AuraEffect const* aurEff = caster->GetDummyAuraEffect(SPELLFAMILY_PRIEST, 3790, 1))
                     {
                         int32 damage = devouringPlague->GetAmount();
-                        damage = target->SpellDamageBonusTaken(caster, GetSpellInfo(), GetSpellInfo()->GetSchoolMask(), damage, DOT);
+                        damage = target->SpellDamageBonusTaken(caster, GetSpellInfo(), damage, DOT);
 
                         CastSpellExtraArgs args(devouringPlague), args2(devouringPlague);
                         int32 basepoints0 = CalculatePct(devouringPlague->GetTotalTicks() * static_cast<int32>(damage), aurEff->GetAmount());

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1435,7 +1435,7 @@ void Aura::HandleAuraSpecificMods(AuraApplication const* aurApp, Unit* caster, b
                     if (AuraEffect const* aurEff = caster->GetDummyAuraEffect(SPELLFAMILY_PRIEST, 3790, 1))
                     {
                         int32 damage = devouringPlague->GetAmount();
-                        damage = target->SpellDamageBonusTaken(caster, GetSpellInfo(), damage, DOT);
+                        damage = target->SpellDamageBonusTaken(caster, GetSpellInfo(), damage, DOT, devouringPlague->GetTotalTicks(), devouringPlague->GetSpellEffectInfo());
 
                         CastSpellExtraArgs args(devouringPlague), args2(devouringPlague);
                         int32 basepoints0 = CalculatePct(devouringPlague->GetTotalTicks() * static_cast<int32>(damage), aurEff->GetAmount());

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -527,10 +527,18 @@ m_caster((info->HasAttribute(SPELL_ATTR6_CAST_BY_CHARMER) && caster->GetCharmerO
     if (Player const* playerCaster = m_caster->ToPlayer())
     {
         // wand case
+        // TODO we should just use the hardcoded shoot ids here, this will allow us to support wand required spells without hijacking the type.
         if (m_attackType == RANGED_ATTACK)
             if ((playerCaster->GetClassMask() & CLASSMASK_WAND_USERS) != 0)
                 if (Item* pItem = playerCaster->GetWeaponForAttack(RANGED_ATTACK))
                     m_spellSchoolMask = SpellSchoolMask(1 << pItem->GetTemplate()->Damage[0].DamageType);
+
+        // bow/gun auto attack
+        // wen need to find the specific spells here as we only want to set the damage type for auto attacks, all other
+        // ranged spells requiring a bow/gun should use the spell's school mask
+        if (m_spellInfo->Id == 75 || m_spellInfo->Id == 3018)
+            if (Item* pItem = playerCaster->GetWeaponForAttack(RANGED_ATTACK))
+                m_spellSchoolMask = SpellSchoolMask(1 << pItem->GetTemplate()->Damage[0].DamageType);
     }
 
     if (originalCasterGUID)

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -519,27 +519,7 @@ m_caster((info->HasAttribute(SPELL_ATTR6_CAST_BY_CHARMER) && caster->GetCharmerO
     m_auraScaleMask = 0;
     memset(m_damageMultipliers, 0, sizeof(m_damageMultipliers));
 
-    // Get data for type of attack
     m_attackType = info->GetAttackType();
-
-    m_spellSchoolMask = info->GetSchoolMask();           // Can be override for some spell (wand shoot for example)
-
-    if (Player const* playerCaster = m_caster->ToPlayer())
-    {
-        // wand case
-        // TODO we should just use the hardcoded shoot ids here, this will allow us to support wand required spells without hijacking the type.
-        if (m_attackType == RANGED_ATTACK)
-            if ((playerCaster->GetClassMask() & CLASSMASK_WAND_USERS) != 0)
-                if (Item* pItem = playerCaster->GetWeaponForAttack(RANGED_ATTACK))
-                    m_spellSchoolMask = SpellSchoolMask(1 << pItem->GetTemplate()->Damage[0].DamageType);
-
-        // bow/gun auto attack
-        // wen need to find the specific spells here as we only want to set the damage type for auto attacks, all other
-        // ranged spells requiring a bow/gun should use the spell's school mask
-        if (m_spellInfo->Id == 75 || m_spellInfo->Id == 3018)
-            if (Item* pItem = playerCaster->GetWeaponForAttack(RANGED_ATTACK))
-                m_spellSchoolMask = SpellSchoolMask(1 << pItem->GetTemplate()->Damage[0].DamageType);
-    }
 
     if (originalCasterGUID)
         m_originalCasterGUID = originalCasterGUID;
@@ -637,6 +617,19 @@ Spell::~Spell()
 
     // missing cleanup somewhere, mem leaks so let's crash
     AssertEffectExecuteData();
+}
+
+// Returns the school mask to use for final spell damage
+SpellSchoolMask Spell::GetDamageSchoolMask() const
+{
+    if (Player const* playerCaster = m_caster->ToPlayer())
+    {
+        // wand/bow/gun shoot/auto attack.  these spells are effectively auto attacks and should use the weapons primary damage type
+        if (m_spellInfo->Id == 75 || m_spellInfo->Id == 3018 || m_spellInfo->Id == 5019)
+            if (Item* pItem = playerCaster->GetWeaponForAttack(RANGED_ATTACK))
+                return SpellSchoolMask(1 << pItem->GetTemplate()->Damage[0].DamageType);
+    }
+    return m_spellInfo->GetSchoolMask();
 }
 
 void Spell::InitExplicitTargets(SpellCastTargets const& targets)
@@ -2590,11 +2583,12 @@ void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
 
         // Do damage
         bool hasDamage = false;
+        SpellSchoolMask damageSchoolMask = spell->GetDamageSchoolMask();
         if (spell->m_damage > 0)
         {
             hasDamage = true;
             // Fill base damage struct (unitTarget - is real spell target)
-            SpellNonMeleeDamage damageInfo(caster, spell->unitTarget, spell->m_spellInfo->Id, spell->m_spellSchoolMask);
+            SpellNonMeleeDamage damageInfo(caster, spell->unitTarget, spell->m_spellInfo->Id, damageSchoolMask);
             // Check damage immunity
             if (spell->unitTarget->IsImmunedToDamage(spell->m_spellInfo))
             {
@@ -2633,7 +2627,7 @@ void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
         if (!hasHealing && !hasDamage)
         {
             // Fill base damage struct (unitTarget - is real spell target)
-            SpellNonMeleeDamage damageInfo(caster, spell->unitTarget, spell->m_spellInfo->Id, spell->m_spellSchoolMask);
+            SpellNonMeleeDamage damageInfo(caster, spell->unitTarget, spell->m_spellInfo->Id, damageSchoolMask);
             hitMask |= createProcHitMask(&damageInfo, MissCondition);
             // Do triggers for unit
             if (canEffectTrigger)
@@ -2812,11 +2806,9 @@ SpellMissInfo Spell::PreprocessSpellHit(Unit* unit, bool scaleAura, TargetInfo& 
         if (creatureTarget->IsEvadingAttacks())
             return SPELL_MISS_EVADE;
 
-    /** @epoch-start */
-    // properly catch wands spell school.
-    if (m_spellInfo->Speed && ((m_damage > 0 && unit->IsImmunedToDamage(m_spellInfo) || unit->IsImmunedToDamage(m_spellSchoolMask) || unit->IsImmunedToSpell(m_spellInfo, m_caster))))
+    SpellSchoolMask damageSchoolMask = GetDamageSchoolMask();
+    if (m_spellInfo->Speed && ((m_damage > 0 && unit->IsImmunedToDamage(m_spellInfo, damageSchoolMask) || unit->IsImmunedToDamage(damageSchoolMask) || unit->IsImmunedToSpell(m_spellInfo, m_caster))))
         return SPELL_MISS_IMMUNE;
-    /** @epoch-end */
 
     if (Player* player = unit->ToPlayer())
     {
@@ -3186,7 +3178,7 @@ SpellCastResult Spell::prepare(SpellCastTargets const& targets, AuraEffect const
     LoadScripts();
 
     // Fill cost data (do not use power for item casts)
-    m_powerCost = m_CastItem ? 0 : m_spellInfo->CalcPowerCost(m_caster, m_spellSchoolMask, this);
+    m_powerCost = m_CastItem ? 0 : m_spellInfo->CalcPowerCost(m_caster, m_spellInfo->GetSchoolMask(), this);
 
     // Set combo point requirement
     if ((_triggeredCastFlags & TRIGGERED_IGNORE_COMBO_POINTS) || m_CastItem)
@@ -6375,7 +6367,7 @@ SpellCastResult Spell::CheckPetCast(Unit* target)
 
     // check power requirement
     // this would be zero until ::prepare normally, we set it here (it gets reset in ::prepare)
-    m_powerCost = m_spellInfo->CalcPowerCost(m_caster, m_spellSchoolMask);
+    m_powerCost = m_spellInfo->CalcPowerCost(m_caster, m_spellInfo->GetSchoolMask());
     SpellCastResult failReason = CheckPower();
     if (failReason != SPELL_CAST_OK)
         return failReason;
@@ -7931,8 +7923,8 @@ void Spell::PreprocessSpellLaunch(TargetInfo& targetInfo)
     if (m_originalCaster)
     {
         if (!critChance)
-            critChance = m_originalCaster->SpellCritChanceDone(m_spellInfo, m_spellSchoolMask, m_attackType);
-        critChance = unit->SpellCritChanceTaken(m_originalCaster, m_spellInfo, m_spellSchoolMask, critChance, m_attackType);
+            critChance = m_originalCaster->SpellCritChanceDone(m_spellInfo, m_spellInfo->GetSchoolMask(), m_attackType);
+        critChance = unit->SpellCritChanceTaken(m_originalCaster, m_spellInfo, m_spellInfo->GetSchoolMask(), critChance, m_attackType);
     }
 
     // @tswow-begin

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -300,6 +300,7 @@ class TC_GAME_API Spell
         Spell(WorldObject* caster, SpellInfo const* info, TriggerCastFlags triggerFlags, ObjectGuid originalCasterGUID = ObjectGuid::Empty);
         ~Spell();
 
+        SpellSchoolMask GetDamageSchoolMask() const;
         void InitExplicitTargets(SpellCastTargets const& targets);
         void SelectExplicitTargets();
 
@@ -510,7 +511,6 @@ class TC_GAME_API Spell
         Unit* m_originalCaster;                             // cached pointer for m_originalCaster, updated at Spell::UpdatePointers()
 
         // Spell data
-        SpellSchoolMask m_spellSchoolMask;                  // Spell school (can be overwrite for some spells (wand shoot for example)
         WeaponAttackType m_attackType;                      // For weapon based attack
         int32 m_powerCost;                                  // Calculated spell cost initialized only in Spell::prepare
         int32 m_casttime;                                   // Calculated spell cast time initialized only in Spell::prepare

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3435,7 +3435,8 @@ void Spell::EffectWeaponDmg()
         }
     }
 
-    // modify the the physical flat_bonus with the physical pct modifier
+    // physical EffectWeaponDmg spells fixed_bonus is always expected to be scaled by pct mods
+    // magic EffectWeaponDmg fixed_bonus is already calculated to the expected value
     if (fixed_bonus > 0 && (m_spellInfo->GetSchoolMask() & SPELL_SCHOOL_MASK_NORMAL))
     {
         UnitMods unitMod;
@@ -3447,8 +3448,8 @@ void Spell::EffectWeaponDmg()
             case RANGED_ATTACK: unitMod = UNIT_MOD_DAMAGE_RANGED;   break;
         }
 
-        float weapon_total_pct = unitCaster->GetPctModifierValue(unitMod, TOTAL_PCT);
-        fixed_bonus = int32(fixed_bonus * weapon_total_pct);
+        float physical_pct_mod = unitCaster->GetDamagePctModifierValue(unitMod, SPELL_SCHOOL_NORMAL);
+        fixed_bonus = int32(fixed_bonus * physical_pct_mod);
     }
 
     // 1. Calculate the base weapon damage to use for the spell

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3224,11 +3224,33 @@ void Spell::EffectWeaponDmg()
         }
     }
 
-    // some spell specific modifiers
-    float totalDamagePercentMod  = 1.0f;                    // applied to final bonus+weapon damage
+    float weaponDamagePercentMod = 1.0f; // Just the SPELL_EFFECT_WEAPON_PERCENT_DAMAGE modifier (e.g. 0.7 for Seal of Command)
+    bool normalized = false; // If any effect is SPELL_EFFECT_NORMALIZED_WEAPON_DMG, our base weapon damage is normalized
     int32 fixed_bonus = 0;
     int32 spell_bonus = 0;                                  // bonus specific for spell
+    float totalDamagePercentMod  = 1.0f;                    // applied to final bonus+weapon damage
 
+    for (SpellEffectInfo const& spellEffectInfo : m_spellInfo->GetEffects())
+    {
+        switch (spellEffectInfo.Effect)
+        {
+            case SPELL_EFFECT_WEAPON_DAMAGE:
+            case SPELL_EFFECT_WEAPON_DAMAGE_NOSCHOOL:
+                fixed_bonus += CalculateDamage(spellEffectInfo);
+                break;
+            case SPELL_EFFECT_NORMALIZED_WEAPON_DMG:
+                fixed_bonus += CalculateDamage(spellEffectInfo);
+                normalized = true;
+                break;
+            case SPELL_EFFECT_WEAPON_PERCENT_DAMAGE:
+                ApplyPct(weaponDamagePercentMod, CalculateDamage(spellEffectInfo));
+                break;
+            default:
+                break;                                      // not weapon damage effect, just skip
+        }
+    }
+
+    // some spell specific modifiers
     switch (m_spellInfo->SpellFamilyName)
     {
         case SPELLFAMILY_WARRIOR:
@@ -3412,33 +3434,13 @@ void Spell::EffectWeaponDmg()
             break;
         }
     }
+    
+    // For spell effects derived from weapon damage we should use the weapons damage school when modifying the weapon bonuses.
+    // Since all weapons do at least normal damage as their primary damage school, it goes that we should always apply the ATTACK TOTAL_PCT modifier
+    // to the fixed bonus.  TODO consider whether this is true for spell_bonus as well.
 
-    bool normalized = false;
-    float weaponDamagePercentMod = 1.0f;
-    for (SpellEffectInfo const& spellEffectInfo : m_spellInfo->GetEffects())
-    {
-        switch (spellEffectInfo.Effect)
-        {
-            case SPELL_EFFECT_WEAPON_DAMAGE:
-            case SPELL_EFFECT_WEAPON_DAMAGE_NOSCHOOL:
-                fixed_bonus += CalculateDamage(spellEffectInfo);
-                break;
-            case SPELL_EFFECT_NORMALIZED_WEAPON_DMG:
-                fixed_bonus += CalculateDamage(spellEffectInfo);
-                normalized = true;
-                break;
-            case SPELL_EFFECT_WEAPON_PERCENT_DAMAGE:
-                ApplyPct(weaponDamagePercentMod, CalculateDamage(spellEffectInfo));
-                break;
-            default:
-                break;                                      // not weapon damage effect, just skip
-        }
-    }
-
-    // if (addPctMods) { percent mods are added in Unit::CalculateDamage } else { percent mods are added in Unit::MeleeDamageBonusDone }
-    // this distinction is neccessary to properly inform the client about his autoattack damage values from Script_UnitDamage
-    bool const addPctMods = !m_spellInfo->HasAttribute(SPELL_ATTR6_LIMIT_PCT_DAMAGE_MODS) && (m_spellSchoolMask & SPELL_SCHOOL_MASK_NORMAL);
-    if (addPctMods)
+    // bool const addPctMods = !m_spellInfo->HasAttribute(SPELL_ATTR6_LIMIT_PCT_DAMAGE_MODS) && (m_spellSchoolMask & SPELL_SCHOOL_MASK_NORMAL);
+    // if (addPctMods)
     {
         UnitMods unitMod;
         switch (m_attackType)
@@ -3456,27 +3458,35 @@ void Spell::EffectWeaponDmg()
             spell_bonus = int32(spell_bonus * weapon_total_pct);
     }
 
-    int32 weaponDamage = unitCaster->CalculateDamage(m_attackType, normalized, addPctMods);
+    // This is a simplification by combining the weapon damages together (like windury adding its nature damage)
+    // to use as the base for the effect.  TODO we can separate these damages out to ensure we don't apply
+    // the percent mods to the secondary damage types if necessary.
+    int32 weaponDamage = unitCaster->CalculateDamage(m_attackType, normalized, true);
 
-    // Sequence is important
-    for (SpellEffectInfo const& spellEffectInfo : m_spellInfo->GetEffects())
-    {
-        // We assume that a spell have at most one fixed_bonus
-        // and at most one weaponDamagePercentMod
-        switch (spellEffectInfo.Effect)
-        {
-            case SPELL_EFFECT_WEAPON_DAMAGE:
-            case SPELL_EFFECT_WEAPON_DAMAGE_NOSCHOOL:
-            case SPELL_EFFECT_NORMALIZED_WEAPON_DMG:
-                weaponDamage += fixed_bonus;
-                break;
-            case SPELL_EFFECT_WEAPON_PERCENT_DAMAGE:
-                weaponDamage = int32(weaponDamage * weaponDamagePercentMod);
-                break;
-            default:
-                break;                                      // not weapon damage effect, just skip
-        }
-    }
+    // // Sequence is important
+    // for (SpellEffectInfo const& spellEffectInfo : m_spellInfo->GetEffects())
+    // {
+    //     // We assume that a spell have at most one fixed_bonus
+    //     // and at most one weaponDamagePercentMod
+    //     switch (spellEffectInfo.Effect)
+    //     {
+    //         case SPELL_EFFECT_WEAPON_DAMAGE:
+    //         case SPELL_EFFECT_WEAPON_DAMAGE_NOSCHOOL:
+    //         case SPELL_EFFECT_NORMALIZED_WEAPON_DMG:
+    //             weaponDamage += fixed_bonus;
+    //             break;
+    //         case SPELL_EFFECT_WEAPON_PERCENT_DAMAGE:
+    //             weaponDamage = int32(weaponDamage * weaponDamagePercentMod);
+    //             break;
+    //         default:
+    //             break;                                      // not weapon damage effect, just skip
+    //     }
+    // }
+    
+    // The ordering above relies on the spell effects being ordered a specific way, but I read it as
+    // the weaponDamagePercentMod should be applied to the base swing before adding the fixed bonus.
+    weaponDamage = int32(weaponDamage * weaponDamagePercentMod);
+    weaponDamage += fixed_bonus;
 
     weaponDamage += spell_bonus;
     weaponDamage = int32(weaponDamage * totalDamagePercentMod);
@@ -3488,14 +3498,13 @@ void Spell::EffectWeaponDmg()
     // prevent negative damage
     weaponDamage = std::max(weaponDamage, 0);
 
-    /** @epoch-start */
-    // Physical bonuses are built in to the weaponDamage, if this spell is not a physical spell, apply the spell bonuses (e.g. Seal of Command)
+    // Now that the spell damage derived from weapon damage is calculated, if the spell converts this into damage into non-physical
+    // we want to treat it like a spell damage effect.
     if (!(m_spellSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
     {
         weaponDamage = unitCaster->SpellDamageBonusDone(unitTarget, m_spellInfo, m_spellSchoolMask, uint32(weaponDamage), SPELL_DIRECT_DAMAGE, 1, *effectInfo, { });
         weaponDamage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, m_spellSchoolMask, uint32(weaponDamage), SPELL_DIRECT_DAMAGE);
     }
-    /** @epoch-end */
 
     m_damage += std::max(weaponDamage, 0);
 }

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3458,7 +3458,7 @@ void Spell::EffectWeaponDmg()
         if (i > 0 && unitCaster->GetTypeId() != TYPEID_PLAYER)
             break;
 
-        SpellSchoolMask schoolMask = unitCaster->GetMeleeDamageSchoolMask(attackType, i);
+        SpellSchoolMask schoolMask = unitCaster->GetMeleeDamageSchoolMask(m_attackType, i);
 
         uint8 itemDamagesMask = (unitCaster->GetTypeId() == TYPEID_PLAYER) ? (1 << i) : 0;
 

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3449,7 +3449,7 @@ void Spell::EffectWeaponDmg()
             case RANGED_ATTACK: unitMod = UNIT_MOD_DAMAGE_RANGED;   break;
         }
 
-        float weapon_total_pct = unitCaster->GetDamagePctModifierValue(unitMod, m_spellSchoolMask);
+        float weapon_total_pct = unitCaster->GetDamagePctModifierValue(unitMod, GetFirstSchoolInMask(m_spellSchoolMask));
         if (fixed_bonus)
             fixed_bonus = int32(fixed_bonus * weapon_total_pct);
         if (spell_bonus)

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3462,7 +3462,7 @@ void Spell::EffectWeaponDmg()
 
         uint8 itemDamagesMask = (unitCaster->GetTypeId() == TYPEID_PLAYER) ? (1 << i) : 0;
 
-        uint32 damage = CalculateDamage(m_attackType, normalized, itemDamagesMask);
+        uint32 damage = unitCaster->CalculateDamage(m_attackType, normalized, itemDamagesMask);
 
         // Add additional melee damage mods to each damage component
         damage = unitCaster->MeleeDamageBonusDone(unitTarget, damage, m_attackType, m_spellInfo);

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3435,7 +3435,9 @@ void Spell::EffectWeaponDmg()
         }
     }
 
-    // modify the fixed bonus with the pct mod of the spells school
+    // pct dmg bonus is already applied to the base weapon damage, so we want to also apply it to the fixed bonus
+    // flat mod wants to 'add a fixed bonus to weapon damage' but there can be only 1 'baseWeaponDmg' type
+    // keeping with existing expectations we assume this type is physical and apply the physical pct mod to the fixed bonus
     UnitMods unitMod;
     switch (m_attackType)
     {
@@ -3445,7 +3447,7 @@ void Spell::EffectWeaponDmg()
         case RANGED_ATTACK: unitMod = UNIT_MOD_DAMAGE_RANGED;   break;
     }
 
-    float weapon_total_pct = unitCaster->GetDamagePctModifierValue(unitMod, GetFirstSchoolInMask(m_spellSchoolMask));
+    float weapon_total_pct = unitCaster->GetPctModifierValue(unitMod, TOTAL_PCT);
     if (fixed_bonus)
         fixed_bonus = int32(fixed_bonus * weapon_total_pct);
 
@@ -3475,6 +3477,13 @@ void Spell::EffectWeaponDmg()
     weaponDamage = int32(weaponDamage * weaponDamagePercentMod);
     weaponDamage += fixed_bonus;
     weaponDamage = int32(weaponDamage * totalDamagePercentMod);
+
+    // 3. If the spell is not physical we treat the resulting damage as a casted spell and apply the spell bonus mods
+    if (weaponDamage > 0 && !(m_spellSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
+    {
+        weaponDamage = unitCaster->SpellDamageBonusDone(unitTarget, m_spellInfo, m_spellSchoolMask, (uint32)weaponDamage, SPELL_DIRECT_DAMAGE, 1, *effectInfo, { });
+        weaponDamage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, m_spellSchoolMask, (uint32)weaponDamage, SPELL_DIRECT_DAMAGE);
+    }
 
     // apply spellmod to Done damage
     if (Player* modOwner = unitCaster->GetSpellModOwner())

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3434,14 +3434,11 @@ void Spell::EffectWeaponDmg()
             break;
         }
     }
-    
-    // For spell effects derived from weapon damage we should use the weapon's damage school when modifying the fixed bonuses.
-    // The caveat here is weapons can have multiple damage schools, so how do we determine which part of the weapon damage
-    // should be used to determine the bonus?  Here we just apply the physical modifier to the fixed bonus for simplicity.
 
-    // TODO remove when confident this is correct
-    // bool const addPctMods = !m_spellInfo->HasAttribute(SPELL_ATTR6_LIMIT_PCT_DAMAGE_MODS) && (m_spellSchoolMask & SPELL_SCHOOL_MASK_NORMAL);
-    // if (addPctMods)
+    //bool const addPctMods = !m_spellInfo->HasAttribute(SPELL_ATTR6_LIMIT_PCT_DAMAGE_MODS) && (m_spellSchoolMask & SPELL_SCHOOL_MASK_NORMAL);
+    //if (addPctMods)
+    // Modify the bonuses by the pct mods for the spells school, if its not limited
+    if (!m_spellInfo->HasAttribute(SPELL_ATTR6_LIMIT_PCT_DAMAGE_MODS))
     {
         UnitMods unitMod;
         switch (m_attackType)
@@ -3452,57 +3449,55 @@ void Spell::EffectWeaponDmg()
             case RANGED_ATTACK: unitMod = UNIT_MOD_DAMAGE_RANGED;   break;
         }
 
-        float weapon_total_pct = unitCaster->GetPctModifierValue(unitMod, TOTAL_PCT);
+        float weapon_total_pct = unitCaster->GetWeaponPctModifierValue(unitMod, m_spellSchoolMask);
         if (fixed_bonus)
             fixed_bonus = int32(fixed_bonus * weapon_total_pct);
         if (spell_bonus)
             spell_bonus = int32(spell_bonus * weapon_total_pct);
     }
 
-    // For weapons with multiple damage schools this will combine both calculated damages
-    // This is our starting point for the spell effect
+    // For weapons with multiple damage schools this will combine both calculated damages into
+    // a single 'weapon damage' with the damage type of the spell. The individual weapon damages
+    // take into account the pct mods for the spell school.
     int32 weaponDamage = unitCaster->CalculateDamage(m_attackType, normalized);
 
-    // TODO remove when confident this is correct
-    // // Sequence is important
-    // for (SpellEffectInfo const& spellEffectInfo : m_spellInfo->GetEffects())
-    // {
-    //     // We assume that a spell have at most one fixed_bonus
-    //     // and at most one weaponDamagePercentMod
-    //     switch (spellEffectInfo.Effect)
-    //     {
-    //         case SPELL_EFFECT_WEAPON_DAMAGE:
-    //         case SPELL_EFFECT_WEAPON_DAMAGE_NOSCHOOL:
-    //         case SPELL_EFFECT_NORMALIZED_WEAPON_DMG:
-    //             weaponDamage += fixed_bonus;
-    //             break;
-    //         case SPELL_EFFECT_WEAPON_PERCENT_DAMAGE:
-    //             weaponDamage = int32(weaponDamage * weaponDamagePercentMod);
-    //             break;
-    //         default:
-    //             break;                                      // not weapon damage effect, just skip
-    //     }
-    // }
-    
-    // The ordering above relies on the spell effects being ordered a specific way, but I read it as
-    // the weaponDamagePercentMod should be applied to the base swing before adding the fixed bonus.
-    weaponDamage = int32(weaponDamage * weaponDamagePercentMod);
-    weaponDamage += fixed_bonus;
+    // Add the EFFECT_WEAPON_DAMAGE mods
+
+    // Sequence is important
+    for (SpellEffectInfo const& spellEffectInfo : m_spellInfo->GetEffects())
+    {
+        // We assume that a spell have at most one fixed_bonus
+        // and at most one weaponDamagePercentMod
+        switch (spellEffectInfo.Effect)
+        {
+            case SPELL_EFFECT_WEAPON_DAMAGE:
+            case SPELL_EFFECT_WEAPON_DAMAGE_NOSCHOOL:
+            case SPELL_EFFECT_NORMALIZED_WEAPON_DMG:
+                weaponDamage += fixed_bonus;
+                break;
+            case SPELL_EFFECT_WEAPON_PERCENT_DAMAGE:
+                weaponDamage = int32(weaponDamage * weaponDamagePercentMod);
+                break;
+            default:
+                break;                                      // not weapon damage effect, just skip
+        }
+    }
 
     weaponDamage += spell_bonus;
     weaponDamage = int32(weaponDamage * totalDamagePercentMod);
 
-    // We want to apply the remaining spell damage modifiers to the weapon damage using the spell's damage school
-    weaponDamage = unitCaster->MeleeDamageBonusDone(unitTarget, weaponDamage, m_attackType, m_spellInfo, m_spellSchoolMask);
+    // Apply the additional melee damage mods to the total weapon damage
+    weaponDamage = unitCaster->MeleeDamageBonusDone(unitTarget, weaponDamage, m_attackType, m_spellInfo);
     weaponDamage = unitTarget->MeleeDamageBonusTaken(unitCaster, weaponDamage, m_attackType, m_spellInfo, m_spellSchoolMask);
 
     // apply spellmod to Done damage
     if (Player* modOwner = unitCaster->GetSpellModOwner())
         modOwner->ApplySpellMod(m_spellInfo->Id, SPELLMOD_DAMAGE, weaponDamage);
 
-    // prevent negative damage
+    // prevent negative damage bonus
     weaponDamage = std::max(weaponDamage, 0);
 
+    // add the bonus
     m_damage += weaponDamage;
 }
 

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1542,7 +1542,7 @@ void Spell::EffectHealthLeech()
         healthGain = unitCaster->SpellHealingBonusDone(unitCaster, m_spellInfo, healthGain, HEAL, 1, *effectInfo, { });
         healthGain = unitCaster->SpellHealingBonusTaken(unitCaster, m_spellInfo, healthGain, HEAL);
 
-        HealInfo healInfo(unitCaster, unitCaster, healthGain, m_spellInfo, m_spellSchoolMask);
+        HealInfo healInfo(unitCaster, unitCaster, healthGain, m_spellInfo, m_spellInfo->GetSchoolMask());
         unitCaster->HealBySpell(healInfo);
     }
 }
@@ -3478,8 +3478,7 @@ void Spell::EffectWeaponDmg()
     weaponDamage += fixed_bonus;
     weaponDamage = int32(weaponDamage * totalDamagePercentMod);
 
-    // 3. If the spell is not physical we treat the resulting damage as a casted spell and apply the spell bonus mods
-    // (DO NOT USE m_spellSchoolMask here as we do not treat wand shoot as a spell)
+    // 3. If the base spell school is not physical we treat the resulting damage as a casted spell and apply the spell bonus mods
     if (weaponDamage > 0 && !(m_spellInfo->GetSchoolMask() & SPELL_SCHOOL_MASK_NORMAL))
     {
         weaponDamage = unitCaster->SpellDamageBonusDone(unitTarget, m_spellInfo, (uint32)weaponDamage, SPELL_DIRECT_DAMAGE, 1, *effectInfo, { });

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3229,7 +3229,7 @@ void Spell::EffectWeaponDmg()
     int32 fixed_bonus = 0; // A flat bonus to the weapon damage
     float totalDamagePercentMod  = 1.0f; // a final pct modifier to the attack damage
 
-    // get all effect modifiers
+    // get all base effect modifiers
     for (SpellEffectInfo const& spellEffectInfo : m_spellInfo->GetEffects())
     {
         switch (spellEffectInfo.Effect)
@@ -3435,21 +3435,21 @@ void Spell::EffectWeaponDmg()
         }
     }
 
-    // pct dmg bonus is already applied to the base weapon damage, so we want to also apply it to the fixed bonus
-    // flat mod wants to 'add a fixed bonus to weapon damage' but there can be only 1 'baseWeaponDmg' type
-    // keeping with existing expectations we assume this type is physical and apply the physical pct mod to the fixed bonus
-    UnitMods unitMod;
-    switch (m_attackType)
+    // modify the the physical flat_bonus with the physical pct modifier
+    if (fixed_bonus > 0 && (m_spellSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
     {
-        default:
-        case BASE_ATTACK:   unitMod = UNIT_MOD_DAMAGE_MAINHAND; break;
-        case OFF_ATTACK:    unitMod = UNIT_MOD_DAMAGE_OFFHAND;  break;
-        case RANGED_ATTACK: unitMod = UNIT_MOD_DAMAGE_RANGED;   break;
-    }
+        UnitMods unitMod;
+        switch (m_attackType)
+        {
+            default:
+            case BASE_ATTACK:   unitMod = UNIT_MOD_DAMAGE_MAINHAND; break;
+            case OFF_ATTACK:    unitMod = UNIT_MOD_DAMAGE_OFFHAND;  break;
+            case RANGED_ATTACK: unitMod = UNIT_MOD_DAMAGE_RANGED;   break;
+        }
 
-    float weapon_total_pct = unitCaster->GetPctModifierValue(unitMod, TOTAL_PCT);
-    if (fixed_bonus)
+        float weapon_total_pct = unitCaster->GetPctModifierValue(unitMod, TOTAL_PCT);
         fixed_bonus = int32(fixed_bonus * weapon_total_pct);
+    }
 
     // 1. Calculate the base weapon damage to use for the spell
     // Spells can only have 1 damage type, so we need to add the damages together

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -667,7 +667,7 @@ void Spell::EffectSchoolDMG()
                     float tmpMin, tmpMax;
                     for (uint8 i = 0; i < MAX_ITEM_PROTO_DAMAGES; ++i)
                     {
-                        unitCaster->CalculateMinMaxDamage(BASE_ATTACK, false, false, tmpMin, tmpMax, i);
+                        unitCaster->CalculateMinMaxDamage(BASE_ATTACK, false, tmpMin, tmpMax, i);
                         minTotal += tmpMin;
                         maxTotal += tmpMax;
                     }
@@ -3459,9 +3459,9 @@ void Spell::EffectWeaponDmg()
             spell_bonus = int32(spell_bonus * weapon_total_pct);
     }
 
-    // for weapons with multiple damage schools this will combine both calculated damages
-    // this is our starting point for the spell effect
-    int32 weaponDamage = unitCaster->CalculateDamage(m_attackType, normalized, true);
+    // For weapons with multiple damage schools this will combine both calculated damages
+    // This is our starting point for the spell effect
+    int32 weaponDamage = unitCaster->CalculateDamage(m_attackType, normalized);
 
     // TODO remove when confident this is correct
     // // Sequence is important

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3435,10 +3435,11 @@ void Spell::EffectWeaponDmg()
         }
     }
     
-    // For spell effects derived from weapon damage we should use the weapons damage school when modifying the weapon bonuses.
-    // Since all weapons do at least normal damage as their primary damage school, it goes that we should always apply the ATTACK TOTAL_PCT modifier
-    // to the fixed bonus.  TODO consider whether this is true for spell_bonus as well.
+    // For spell effects derived from weapon damage we should use the weapon's damage school when modifying the fixed bonuses.
+    // The caveat here is weapons can have multiple damage schools, so how do we determine which part of the weapon damage
+    // should be used to determine the bonus?  Here we just apply the physical modifier to the fixed bonus for simplicity.
 
+    // TODO remove when confident this is correct
     // bool const addPctMods = !m_spellInfo->HasAttribute(SPELL_ATTR6_LIMIT_PCT_DAMAGE_MODS) && (m_spellSchoolMask & SPELL_SCHOOL_MASK_NORMAL);
     // if (addPctMods)
     {
@@ -3458,11 +3459,11 @@ void Spell::EffectWeaponDmg()
             spell_bonus = int32(spell_bonus * weapon_total_pct);
     }
 
-    // This is a simplification by combining the weapon damages together (like windury adding its nature damage)
-    // to use as the base for the effect.  TODO we can separate these damages out to ensure we don't apply
-    // the percent mods to the secondary damage types if necessary.
+    // for weapons with multiple damage schools this will combine both calculated damages
+    // this is our starting point for the spell effect
     int32 weaponDamage = unitCaster->CalculateDamage(m_attackType, normalized, true);
 
+    // TODO remove when confident this is correct
     // // Sequence is important
     // for (SpellEffectInfo const& spellEffectInfo : m_spellInfo->GetEffects())
     // {
@@ -3491,6 +3492,10 @@ void Spell::EffectWeaponDmg()
     weaponDamage += spell_bonus;
     weaponDamage = int32(weaponDamage * totalDamagePercentMod);
 
+    // We want to apply the remaining spell damage modifiers to the weapon damage using the spell's damage school
+    weaponDamage = unitCaster->MeleeDamageBonusDone(unitTarget, weaponDamage, m_attackType, m_spellInfo, m_spellSchoolMask);
+    weaponDamage = unitTarget->MeleeDamageBonusTaken(unitCaster, weaponDamage, m_attackType, m_spellInfo, m_spellSchoolMask);
+
     // apply spellmod to Done damage
     if (Player* modOwner = unitCaster->GetSpellModOwner())
         modOwner->ApplySpellMod(m_spellInfo->Id, SPELLMOD_DAMAGE, weaponDamage);
@@ -3498,15 +3503,7 @@ void Spell::EffectWeaponDmg()
     // prevent negative damage
     weaponDamage = std::max(weaponDamage, 0);
 
-    // Now that the spell damage derived from weapon damage is calculated, if the spell converts this into damage into non-physical
-    // we want to treat it like a spell damage effect.
-    if (!(m_spellSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
-    {
-        weaponDamage = unitCaster->SpellDamageBonusDone(unitTarget, m_spellInfo, m_spellSchoolMask, uint32(weaponDamage), SPELL_DIRECT_DAMAGE, 1, *effectInfo, { });
-        weaponDamage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, m_spellSchoolMask, uint32(weaponDamage), SPELL_DIRECT_DAMAGE);
-    }
-
-    m_damage += std::max(weaponDamage, 0);
+    m_damage += weaponDamage;
 }
 
 void Spell::EffectThreat()

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -712,7 +712,7 @@ void Spell::EffectSchoolDMG()
             if (m_triggeredByAuraIsPeriodic)
                 totalTicks = m_triggeredByAuraTotalTicks;
             damage = unitCaster->SpellDamageBonusDone(unitTarget, m_spellInfo, (uint32)damage, SPELL_DIRECT_DAMAGE, totalTicks, *effectInfo, { });
-            damage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, (uint32)damage, SPELL_DIRECT_DAMAGE);
+            damage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, (uint32)damage, SPELL_DIRECT_DAMAGE, totalTicks, *effectInfo);
         }
 
         m_damage += damage;
@@ -1158,7 +1158,7 @@ void Spell::EffectPowerDrain()
     if (unitCaster)
     {
         damage = unitCaster->SpellDamageBonusDone(unitTarget, m_spellInfo, uint32(damage), SPELL_DIRECT_DAMAGE, 1, *effectInfo, { });
-        damage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, uint32(damage), SPELL_DIRECT_DAMAGE);
+        damage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, uint32(damage), SPELL_DIRECT_DAMAGE, 1, *effectInfo);
     }
 
     // resilience reduce mana draining effect at spell crit damage reduction (added in 2.4)
@@ -1520,7 +1520,7 @@ void Spell::EffectHealthLeech()
     if (unitCaster)
     {
         damage = unitCaster->SpellDamageBonusDone(unitTarget, m_spellInfo, uint32(damage), SPELL_DIRECT_DAMAGE, 1, *effectInfo, { });
-        damage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, uint32(damage), SPELL_DIRECT_DAMAGE);
+        damage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, uint32(damage), SPELL_DIRECT_DAMAGE, 1, *effectInfo);
     }
 
     TC_LOG_DEBUG("spells", "HealthLeech :{}", damage);
@@ -3483,7 +3483,7 @@ void Spell::EffectWeaponDmg()
     if (weaponDamage > 0 && !(m_spellInfo->GetSchoolMask() & SPELL_SCHOOL_MASK_NORMAL))
     {
         weaponDamage = unitCaster->SpellDamageBonusDone(unitTarget, m_spellInfo, (uint32)weaponDamage, SPELL_DIRECT_DAMAGE, 1, *effectInfo, { });
-        weaponDamage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, (uint32)weaponDamage, SPELL_DIRECT_DAMAGE);
+        weaponDamage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, (uint32)weaponDamage, SPELL_DIRECT_DAMAGE, 1, *effectInfo);
     }
 
     // apply spellmod to Done damage

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3435,8 +3435,6 @@ void Spell::EffectWeaponDmg()
         }
     }
 
-    //bool const addPctMods = !m_spellInfo->HasAttribute(SPELL_ATTR6_LIMIT_PCT_DAMAGE_MODS) && (m_spellSchoolMask & SPELL_SCHOOL_MASK_NORMAL);
-    //if (addPctMods)
     // Modify the bonuses by the pct mods for the spells school, if its not limited
     if (!m_spellInfo->HasAttribute(SPELL_ATTR6_LIMIT_PCT_DAMAGE_MODS))
     {

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -439,7 +439,7 @@ void Spell::EffectSchoolDMG()
                     // {
                     //     // Calculate damage of Immolate/Shadowflame tick
                     //     int32 pdamage = aura->GetAmount();
-                    //     pdamage = unitTarget->SpellDamageBonusTaken(unitCaster, aura->GetSpellInfo(), aura->GetSpellInfo()->GetSchoolMask(), pdamage, DOT);
+                    //     pdamage = unitTarget->SpellDamageBonusTaken(unitCaster, aura->GetSpellInfo(), pdamage, DOT);
 
                     //     // And multiply by amount of ticks to get damage potential
                     //     pdamage *= aura->GetSpellInfo()->GetMaxTicks();
@@ -711,8 +711,8 @@ void Spell::EffectSchoolDMG()
             uint32 totalTicks = 1;
             if (m_triggeredByAuraIsPeriodic)
                 totalTicks = m_triggeredByAuraTotalTicks;
-            damage = unitCaster->SpellDamageBonusDone(unitTarget, m_spellInfo, m_spellSchoolMask, (uint32)damage, SPELL_DIRECT_DAMAGE, totalTicks, *effectInfo, { });
-            damage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, m_spellSchoolMask, (uint32)damage, SPELL_DIRECT_DAMAGE);
+            damage = unitCaster->SpellDamageBonusDone(unitTarget, m_spellInfo, (uint32)damage, SPELL_DIRECT_DAMAGE, totalTicks, *effectInfo, { });
+            damage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, (uint32)damage, SPELL_DIRECT_DAMAGE);
         }
 
         m_damage += damage;
@@ -1157,8 +1157,8 @@ void Spell::EffectPowerDrain()
     // add spell damage bonus
     if (unitCaster)
     {
-        damage = unitCaster->SpellDamageBonusDone(unitTarget, m_spellInfo, m_spellSchoolMask, uint32(damage), SPELL_DIRECT_DAMAGE, 1, *effectInfo, { });
-        damage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, m_spellSchoolMask, uint32(damage), SPELL_DIRECT_DAMAGE);
+        damage = unitCaster->SpellDamageBonusDone(unitTarget, m_spellInfo, uint32(damage), SPELL_DIRECT_DAMAGE, 1, *effectInfo, { });
+        damage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, uint32(damage), SPELL_DIRECT_DAMAGE);
     }
 
     // resilience reduce mana draining effect at spell crit damage reduction (added in 2.4)
@@ -1519,8 +1519,8 @@ void Spell::EffectHealthLeech()
     Unit* unitCaster = GetUnitCasterForEffectHandlers();
     if (unitCaster)
     {
-        damage = unitCaster->SpellDamageBonusDone(unitTarget, m_spellInfo, m_spellSchoolMask, uint32(damage), SPELL_DIRECT_DAMAGE, 1, *effectInfo, { });
-        damage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, m_spellSchoolMask, uint32(damage), SPELL_DIRECT_DAMAGE);
+        damage = unitCaster->SpellDamageBonusDone(unitTarget, m_spellInfo, uint32(damage), SPELL_DIRECT_DAMAGE, 1, *effectInfo, { });
+        damage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, uint32(damage), SPELL_DIRECT_DAMAGE);
     }
 
     TC_LOG_DEBUG("spells", "HealthLeech :{}", damage);
@@ -3436,7 +3436,7 @@ void Spell::EffectWeaponDmg()
     }
 
     // modify the the physical flat_bonus with the physical pct modifier
-    if (fixed_bonus > 0 && (m_spellSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
+    if (fixed_bonus > 0 && (m_spellInfo->GetSchoolMask() & SPELL_SCHOOL_MASK_NORMAL))
     {
         UnitMods unitMod;
         switch (m_attackType)
@@ -3479,10 +3479,11 @@ void Spell::EffectWeaponDmg()
     weaponDamage = int32(weaponDamage * totalDamagePercentMod);
 
     // 3. If the spell is not physical we treat the resulting damage as a casted spell and apply the spell bonus mods
-    if (weaponDamage > 0 && !(m_spellSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
+    // (DO NOT USE m_spellSchoolMask here as we do not treat wand shoot as a spell)
+    if (weaponDamage > 0 && !(m_spellInfo->GetSchoolMask() & SPELL_SCHOOL_MASK_NORMAL))
     {
-        weaponDamage = unitCaster->SpellDamageBonusDone(unitTarget, m_spellInfo, m_spellSchoolMask, (uint32)weaponDamage, SPELL_DIRECT_DAMAGE, 1, *effectInfo, { });
-        weaponDamage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, m_spellSchoolMask, (uint32)weaponDamage, SPELL_DIRECT_DAMAGE);
+        weaponDamage = unitCaster->SpellDamageBonusDone(unitTarget, m_spellInfo, (uint32)weaponDamage, SPELL_DIRECT_DAMAGE, 1, *effectInfo, { });
+        weaponDamage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, (uint32)weaponDamage, SPELL_DIRECT_DAMAGE);
     }
 
     // apply spellmod to Done damage

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3245,9 +3245,9 @@ void Spell::EffectWeaponDmg()
             //     if (Aura* aur = unitTarget->GetAura(58567, unitCaster->GetGUID()))
             //         fixed_bonus += (aur->GetStackAmount() - 1) * CalculateDamage(m_spellInfo->GetEffect(EFFECT_2)); // subtract 1 so fixed bonus is not applied twice
             // }
+            /** @epoch-end */
             if (m_spellInfo->SpellFamilyFlags[0] & 0x8000000) // Mocking Blow
             {
-            /** @epoch-end */
                 if (unitTarget->IsImmunedToSpellEffect(m_spellInfo, m_spellInfo->GetEffect(EFFECT_1), unitCaster) || unitTarget->GetTypeId() == TYPEID_PLAYER)
                 {
                     m_damage = 0;
@@ -3488,11 +3488,16 @@ void Spell::EffectWeaponDmg()
     // prevent negative damage
     weaponDamage = std::max(weaponDamage, 0);
 
-    // Add melee damage bonuses (also check for negative)
     /** @epoch-start */
-    weaponDamage = unitCaster->MeleeDamageBonusDone(unitTarget, weaponDamage, m_attackType, m_spellInfo, m_spellSchoolMask);
-    m_damage += unitTarget->MeleeDamageBonusTaken(unitCaster, weaponDamage, m_attackType, m_spellInfo, m_spellSchoolMask);
+    // Physical bonuses are built in to the weaponDamage, if this spell is not a physical spell, apply the spell bonuses (e.g. Seal of Command)
+    if (!(m_spellSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
+    {
+        weaponDamage = unitCaster->SpellDamageBonusDone(unitTarget, m_spellInfo, m_spellSchoolMask, uint32(weaponDamage), SPELL_DIRECT_DAMAGE, 1, *effectInfo, { });
+        weaponDamage = unitTarget->SpellDamageBonusTaken(unitCaster, m_spellInfo, m_spellSchoolMask, uint32(weaponDamage), SPELL_DIRECT_DAMAGE);
+    }
     /** @epoch-end */
+
+    m_damage += std::max(weaponDamage, 0);
 }
 
 void Spell::EffectThreat()

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3224,12 +3224,12 @@ void Spell::EffectWeaponDmg()
         }
     }
 
-    float weaponDamagePercentMod = 1.0f; // Just the SPELL_EFFECT_WEAPON_PERCENT_DAMAGE modifier (e.g. 0.7 for Seal of Command)
-    bool normalized = false; // If any effect is SPELL_EFFECT_NORMALIZED_WEAPON_DMG, our base weapon damage is normalized
-    int32 fixed_bonus = 0;
-    int32 spell_bonus = 0;                                  // bonus specific for spell
-    float totalDamagePercentMod  = 1.0f;                    // applied to final bonus+weapon damage
+    float weaponDamagePercentMod = 1.0f; // SPELL_EFFECT_WEAPON_PERCENT_DAMAGE modifier (e.g. 0.7 for Seal of Command, 1.0 for Sinister Strike)
+    bool normalized = false; // If any effect is SPELL_EFFECT_NORMALIZED_WEAPON_DMG the base weapon damage is normalized
+    int32 fixed_bonus = 0; // A flat bonus to the weapon damage
+    float totalDamagePercentMod  = 1.0f; // a final pct modifier to the attack damage
 
+    // get all effect modifiers
     for (SpellEffectInfo const& spellEffectInfo : m_spellInfo->GetEffects())
     {
         switch (spellEffectInfo.Effect)
@@ -3246,7 +3246,7 @@ void Spell::EffectWeaponDmg()
                 ApplyPct(weaponDamagePercentMod, CalculateDamage(spellEffectInfo));
                 break;
             default:
-                break;                                      // not weapon damage effect, just skip
+                break; // not weapon damage effect, just skip
         }
     }
 
@@ -3326,11 +3326,11 @@ void Spell::EffectWeaponDmg()
         }
         case SPELLFAMILY_PALADIN:
         {
-            // Seal of Command Unleashed
+            // Judgement of Command
             if (m_spellInfo->Id == 20467)
             {
-                spell_bonus += int32(0.08f * unitCaster->GetTotalAttackPowerValue(BASE_ATTACK));
-                spell_bonus += int32(0.13f * unitCaster->SpellBaseDamageBonusDone(m_spellInfo->GetSchoolMask()));
+                fixed_bonus += int32(0.08f * unitCaster->GetTotalAttackPowerValue(BASE_ATTACK));
+                fixed_bonus += int32(0.13f * unitCaster->SpellBaseDamageBonusDone(m_spellInfo->GetSchoolMask()));
             }
             break;
         }
@@ -3360,7 +3360,7 @@ void Spell::EffectWeaponDmg()
         {
             // Kill Shot - bonus damage from Ranged Attack Power
             if (m_spellInfo->SpellFamilyFlags[1] & 0x800000)
-                spell_bonus += int32(0.4f * unitCaster->GetTotalAttackPowerValue(RANGED_ATTACK));
+                fixed_bonus += int32(0.4f * unitCaster->GetTotalAttackPowerValue(RANGED_ATTACK));
             break;
         }
         case SPELLFAMILY_DEATHKNIGHT:
@@ -3435,68 +3435,53 @@ void Spell::EffectWeaponDmg()
         }
     }
 
-    // Modify the bonuses by the pct mods for the spells school, if its not limited
-    if (!m_spellInfo->HasAttribute(SPELL_ATTR6_LIMIT_PCT_DAMAGE_MODS))
+    // modify the fixed bonus with the pct mod of the spells school
+    UnitMods unitMod;
+    switch (m_attackType)
     {
-        UnitMods unitMod;
-        switch (m_attackType)
-        {
-            default:
-            case BASE_ATTACK:   unitMod = UNIT_MOD_DAMAGE_MAINHAND; break;
-            case OFF_ATTACK:    unitMod = UNIT_MOD_DAMAGE_OFFHAND;  break;
-            case RANGED_ATTACK: unitMod = UNIT_MOD_DAMAGE_RANGED;   break;
-        }
-
-        float weapon_total_pct = unitCaster->GetDamagePctModifierValue(unitMod, GetFirstSchoolInMask(m_spellSchoolMask));
-        if (fixed_bonus)
-            fixed_bonus = int32(fixed_bonus * weapon_total_pct);
-        if (spell_bonus)
-            spell_bonus = int32(spell_bonus * weapon_total_pct);
+        default:
+        case BASE_ATTACK:   unitMod = UNIT_MOD_DAMAGE_MAINHAND; break;
+        case OFF_ATTACK:    unitMod = UNIT_MOD_DAMAGE_OFFHAND;  break;
+        case RANGED_ATTACK: unitMod = UNIT_MOD_DAMAGE_RANGED;   break;
     }
 
-    // For weapons with multiple damage schools this will combine both calculated damages into
-    // a single 'weapon damage' with the damage type of the spell. The individual weapon damages
-    // take into account the pct mods for the spell school.
-    int32 weaponDamage = unitCaster->CalculateDamage(m_attackType, normalized);
+    float weapon_total_pct = unitCaster->GetDamagePctModifierValue(unitMod, GetFirstSchoolInMask(m_spellSchoolMask));
+    if (fixed_bonus)
+        fixed_bonus = int32(fixed_bonus * weapon_total_pct);
 
-    // Add the EFFECT_WEAPON_DAMAGE mods
-
-    // Sequence is important
-    for (SpellEffectInfo const& spellEffectInfo : m_spellInfo->GetEffects())
+    // 1. Calculate the base weapon damage to use for the spell
+    // Spells can only have 1 damage type, so we need to add the damages together
+    int32 weaponDamage = 0;
+    for (uint8 i = 0; i < MAX_ITEM_PROTO_DAMAGES; ++i)
     {
-        // We assume that a spell have at most one fixed_bonus
-        // and at most one weaponDamagePercentMod
-        switch (spellEffectInfo.Effect)
-        {
-            case SPELL_EFFECT_WEAPON_DAMAGE:
-            case SPELL_EFFECT_WEAPON_DAMAGE_NOSCHOOL:
-            case SPELL_EFFECT_NORMALIZED_WEAPON_DMG:
-                weaponDamage += fixed_bonus;
-                break;
-            case SPELL_EFFECT_WEAPON_PERCENT_DAMAGE:
-                weaponDamage = int32(weaponDamage * weaponDamagePercentMod);
-                break;
-            default:
-                break;                                      // not weapon damage effect, just skip
-        }
+        // only players have secondary weapon damage
+        if (i > 0 && unitCaster->GetTypeId() != TYPEID_PLAYER)
+            break;
+
+        SpellSchoolMask schoolMask = unitCaster->GetMeleeDamageSchoolMask(attackType, i);
+
+        uint8 itemDamagesMask = (unitCaster->GetTypeId() == TYPEID_PLAYER) ? (1 << i) : 0;
+
+        uint32 damage = CalculateDamage(m_attackType, normalized, itemDamagesMask);
+
+        // Add additional melee damage mods to each damage component
+        damage = unitCaster->MeleeDamageBonusDone(unitTarget, damage, m_attackType, m_spellInfo);
+        damage = unitTarget->MeleeDamageBonusTaken(unitCaster, damage, m_attackType, m_spellInfo, schoolMask);
+
+        weaponDamage += damage;
     }
 
-    weaponDamage += spell_bonus;
+    // 2. Apply the spell damage modifiers
+    weaponDamage = int32(weaponDamage * weaponDamagePercentMod);
+    weaponDamage += fixed_bonus;
     weaponDamage = int32(weaponDamage * totalDamagePercentMod);
-
-    // Apply the additional melee damage mods to the total weapon damage
-    weaponDamage = unitCaster->MeleeDamageBonusDone(unitTarget, weaponDamage, m_attackType, m_spellInfo);
-    weaponDamage = unitTarget->MeleeDamageBonusTaken(unitCaster, weaponDamage, m_attackType, m_spellInfo, m_spellSchoolMask);
 
     // apply spellmod to Done damage
     if (Player* modOwner = unitCaster->GetSpellModOwner())
         modOwner->ApplySpellMod(m_spellInfo->Id, SPELLMOD_DAMAGE, weaponDamage);
 
     // prevent negative damage bonus
-    weaponDamage = std::max(weaponDamage, 0);
-
-    // add the bonus
-    m_damage += weaponDamage;
+    m_damage += std::max(weaponDamage, 0);
 }
 
 void Spell::EffectThreat()

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3449,7 +3449,7 @@ void Spell::EffectWeaponDmg()
             case RANGED_ATTACK: unitMod = UNIT_MOD_DAMAGE_RANGED;   break;
         }
 
-        float weapon_total_pct = unitCaster->GetWeaponPctModifierValue(unitMod, m_spellSchoolMask);
+        float weapon_total_pct = unitCaster->GetDamagePctModifierValue(unitMod, m_spellSchoolMask);
         if (fixed_bonus)
             fixed_bonus = int32(fixed_bonus * weapon_total_pct);
         if (spell_bonus)

--- a/src/server/scripts/Spells/spell_pet.cpp
+++ b/src/server/scripts/Spells/spell_pet.cpp
@@ -1723,7 +1723,7 @@ public:
                     ((Guardian*)pet)->SetBonusDamage(owner->GetTotalAttackPowerValue(BASE_ATTACK));
 
                 for (uint8 i = 0; i < MAX_ITEM_PROTO_DAMAGES; ++i)
-                    amount += owner->CalculateDamage(BASE_ATTACK, true, true, i);
+                    amount += owner->CalculateDamage(BASE_ATTACK, true, i);
             }
         }
 

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1160,7 +1160,7 @@ class spell_pri_vampiric_touch : public AuraScript
                 {
                     // backfire damage
                     int32 bp = aurEff->GetAmount();
-                    bp = target->SpellDamageBonusTaken(caster, aurEff->GetSpellInfo(), aurEff->GetSpellInfo()->GetSchoolMask(), bp, DOT);
+                    bp = target->SpellDamageBonusTaken(caster, aurEff->GetSpellInfo(), bp, DOT);
                     bp *= 8;
 
                     CastSpellExtraArgs args(aurEff);

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1160,7 +1160,7 @@ class spell_pri_vampiric_touch : public AuraScript
                 {
                     // backfire damage
                     int32 bp = aurEff->GetAmount();
-                    bp = target->SpellDamageBonusTaken(caster, aurEff->GetSpellInfo(), bp, DOT);
+                    bp = target->SpellDamageBonusTaken(caster, aurEff->GetSpellInfo(), bp, DOT, 1, aurEff->GetSpellEffectInfo());
                     bp *= 8;
 
                     CastSpellExtraArgs args(aurEff);

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -975,7 +975,7 @@ class spell_warl_seed_of_corruption_dummy : public AuraScript
             return;
 
         // effect 1 scales with 14% of caster's SP (DBC data)
-        amount = caster->SpellDamageBonusDone(GetUnitOwner(), GetSpellInfo(), GetSpellInfo()->GetSchoolMask(), amount, SPELL_DIRECT_DAMAGE, 1, aurEff->GetSpellEffectInfo(), GetAura()->GetDonePct());
+        amount = caster->SpellDamageBonusDone(GetUnitOwner(), GetSpellInfo(), amount, SPELL_DIRECT_DAMAGE, 1, aurEff->GetSpellEffectInfo(), GetAura()->GetDonePct());
     }
 
     void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
@@ -1249,7 +1249,7 @@ class spell_warl_unstable_affliction : public AuraScript
                 if (Unit* target = dispelInfo->GetDispeller()->ToUnit())
                 {
                     int32 bp = aurEff->GetAmount();
-                    bp = target->SpellDamageBonusTaken(caster, aurEff->GetSpellInfo(), aurEff->GetSpellInfo()->GetSchoolMask(), bp, DOT);
+                    bp = target->SpellDamageBonusTaken(caster, aurEff->GetSpellInfo(), bp, DOT);
                     bp *= 9;
 
                     // backfire damage and silence

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -1249,7 +1249,7 @@ class spell_warl_unstable_affliction : public AuraScript
                 if (Unit* target = dispelInfo->GetDispeller()->ToUnit())
                 {
                     int32 bp = aurEff->GetAmount();
-                    bp = target->SpellDamageBonusTaken(caster, aurEff->GetSpellInfo(), bp, DOT);
+                    bp = target->SpellDamageBonusTaken(caster, aurEff->GetSpellInfo(), bp, DOT, 1, aurEff->GetSpellEffectInfo());
                     bp *= 9;
 
                     // backfire damage and silence


### PR DESCRIPTION
Added full support for elemental and dual weapon damage types.
Removed non-physical flat bonuses for melee spells that use a magic school (Seal of Command)