### PR TITLE
Spell Damage immunity fixes

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2450,7 +2450,7 @@ void Creature::LoadTemplateImmunities()
     }
 }
 
-bool Creature::IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* caster, bool requireImmunityPurgesEffectAttribute /*= false*/) const
+bool Creature::IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* caster, SpellSchoolMask damageSchoolMask /*= SPELL_SCHOOL_MASK_NONE*/, bool requireImmunityPurgesEffectAttribute /*= false*/) const
 {
     if (!spellInfo)
         return false;
@@ -2468,7 +2468,7 @@ bool Creature::IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* c
     if (immunedToAllEffects)
         return true;
 
-    return Unit::IsImmunedToSpell(spellInfo, caster, requireImmunityPurgesEffectAttribute);
+    return Unit::IsImmunedToSpell(spellInfo, caster, damageSchoolMask, requireImmunityPurgesEffectAttribute);
 }
 
 bool Creature::IsImmunedToSpellEffect(SpellInfo const* spellInfo, SpellEffectInfo const& spellEffectInfo, WorldObject const* caster,

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2450,7 +2450,7 @@ void Creature::LoadTemplateImmunities()
     }
 }
 
-bool Creature::IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* caster, SpellSchoolMask damageSchoolMask /*= SPELL_SCHOOL_MASK_NONE*/, bool requireImmunityPurgesEffectAttribute /*= false*/) const
+bool Creature::IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* caster, bool requireImmunityPurgesEffectAttribute /*= false*/, SpellSchoolMask damageSchoolMask /*= SPELL_SCHOOL_MASK_NONE*/) const
 {
     if (!spellInfo)
         return false;
@@ -2468,7 +2468,7 @@ bool Creature::IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* c
     if (immunedToAllEffects)
         return true;
 
-    return Unit::IsImmunedToSpell(spellInfo, caster, damageSchoolMask, requireImmunityPurgesEffectAttribute);
+    return Unit::IsImmunedToSpell(spellInfo, caster, requireImmunityPurgesEffectAttribute, damageSchoolMask);
 }
 
 bool Creature::IsImmunedToSpellEffect(SpellInfo const* spellInfo, SpellEffectInfo const& spellEffectInfo, WorldObject const* caster,

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -148,7 +148,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         bool CanResetTalents(Player* player, bool pet) const;
         bool CanCreatureAttack(Unit const* victim, bool force = true, bool checkAccessible = true) const;
         void LoadTemplateImmunities();
-        bool IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* caster, SpellSchoolMask damageSchoolMask = SPELL_SCHOOL_MASK_NONE, bool requireImmunityPurgesEffectAttribute = false) const override;
+        bool IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* caster, bool requireImmunityPurgesEffectAttribute = false, SpellSchoolMask damageSchoolMask = SPELL_SCHOOL_MASK_NONE) const override;
         bool IsImmunedToSpellEffect(SpellInfo const* spellInfo, SpellEffectInfo const& spellEffectInfo, WorldObject const* caster, bool requireImmunityPurgesEffectAttribute = false) const override;
         bool isElite() const;
         bool isWorldBoss() const;

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -148,7 +148,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         bool CanResetTalents(Player* player, bool pet) const;
         bool CanCreatureAttack(Unit const* victim, bool force = true, bool checkAccessible = true) const;
         void LoadTemplateImmunities();
-        bool IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* caster, bool requireImmunityPurgesEffectAttribute = false) const override;
+        bool IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* caster, SpellSchoolMask damageSchoolMask = SPELL_SCHOOL_MASK_NONE, bool requireImmunityPurgesEffectAttribute = false) const override;
         bool IsImmunedToSpellEffect(SpellInfo const* spellInfo, SpellEffectInfo const& spellEffectInfo, WorldObject const* caster, bool requireImmunityPurgesEffectAttribute = false) const override;
         bool isElite() const;
         bool isWorldBoss() const;

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2676,18 +2676,15 @@ SpellMissInfo WorldObject::MagicSpellHitResult(Unit* victim, SpellInfo const* sp
 //   Resist
 SpellMissInfo WorldObject::SpellHitResult(Unit* victim, SpellInfo const* spellInfo, SpellSchoolMask damageSchoolMask, bool canReflect /*= false*/) const
 {
-    TC_LOG_DEBUG("immunity", "WorldObject::SpellHitResult damageSchoolMask {} spell immune {}", uint32(damageSchoolMask), victim->IsImmunedToSpell(spellInfo, this, false, damageSchoolMask));
     // Check for immune
     if (victim->IsImmunedToSpell(spellInfo, this, false, damageSchoolMask))
         return SPELL_MISS_IMMUNE;
 
-    TC_LOG_DEBUG("immunity", "WorldObject::SpellHitResult damageSchoolMask {} damage immune {}", uint32(damageSchoolMask), victim->IsImmunedToDamage(spellInfo, damageSchoolMask));
     // Damage immunity is only checked if the spell has damage effects, this immunity must not prevent aura apply
     // returns SPELL_MISS_IMMUNE in that case, for other spells, the SMSG_SPELL_GO must show hit
     if (spellInfo->HasOnlyDamageEffects() && victim->IsImmunedToDamage(spellInfo, damageSchoolMask))
         return SPELL_MISS_IMMUNE;
 
-    TC_LOG_DEBUG("immunity", "WorldObject::SpellHitResult passed immunes");
     // All positive spells can`t miss
     /// @todo client not show miss log for this spells - so need find info for this in dbc and use it!
     if (spellInfo->IsPositive() && !IsHostileTo(victim)) // prevent from affecting enemy by "positive" spell

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2674,17 +2674,17 @@ SpellMissInfo WorldObject::MagicSpellHitResult(Unit* victim, SpellInfo const* sp
 //   Parry
 // For spells
 //   Resist
-SpellMissInfo WorldObject::SpellHitResult(Unit* victim, SpellInfo const* spellInfo, bool canReflect /*= false*/) const
+SpellMissInfo WorldObject::SpellHitResult(Unit* victim, SpellInfo const* spellInfo, SpellSchoolMask damageSchoolMask, bool canReflect /*= false*/) const
 {
-    TC_LOG_DEBUG("immunity", "WorldObject::SpellHitResult checking for spell immune {}", victim->IsImmunedToSpell(spellInfo, this));
+    TC_LOG_DEBUG("immunity", "WorldObject::SpellHitResult checking for spell immune {}", victim->IsImmunedToSpell(spellInfo, this, false, damageSchoolMask));
     // Check for immune
-    if (victim->IsImmunedToSpell(spellInfo, this))
+    if (victim->IsImmunedToSpell(spellInfo, this, false, damageSchoolMask))
         return SPELL_MISS_IMMUNE;
 
-    TC_LOG_DEBUG("immunity", "WorldObject::SpellHitResult checking for damage immune {}", victim->IsImmunedToDamage(spellInfo));
+    TC_LOG_DEBUG("immunity", "WorldObject::SpellHitResult checking for damage immune {}", victim->IsImmunedToDamage(spellInfo, damageSchoolMask));
     // Damage immunity is only checked if the spell has damage effects, this immunity must not prevent aura apply
     // returns SPELL_MISS_IMMUNE in that case, for other spells, the SMSG_SPELL_GO must show hit
-    if (spellInfo->HasOnlyDamageEffects() && victim->IsImmunedToDamage(spellInfo))
+    if (spellInfo->HasOnlyDamageEffects() && victim->IsImmunedToDamage(spellInfo, damageSchoolMask))
         return SPELL_MISS_IMMUNE;
 
     TC_LOG_DEBUG("immunity", "WorldObject::SpellHitResult passed immunes");

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2676,12 +2676,12 @@ SpellMissInfo WorldObject::MagicSpellHitResult(Unit* victim, SpellInfo const* sp
 //   Resist
 SpellMissInfo WorldObject::SpellHitResult(Unit* victim, SpellInfo const* spellInfo, SpellSchoolMask damageSchoolMask, bool canReflect /*= false*/) const
 {
-    TC_LOG_DEBUG("immunity", "WorldObject::SpellHitResult checking for spell immune {}", victim->IsImmunedToSpell(spellInfo, this, false, damageSchoolMask));
+    TC_LOG_DEBUG("immunity", "WorldObject::SpellHitResult damageSchoolMask {} spell immune {}", uint32(damageSchoolMask), victim->IsImmunedToSpell(spellInfo, this, false, damageSchoolMask));
     // Check for immune
     if (victim->IsImmunedToSpell(spellInfo, this, false, damageSchoolMask))
         return SPELL_MISS_IMMUNE;
 
-    TC_LOG_DEBUG("immunity", "WorldObject::SpellHitResult checking for damage immune {}", victim->IsImmunedToDamage(spellInfo, damageSchoolMask));
+    TC_LOG_DEBUG("immunity", "WorldObject::SpellHitResult damageSchoolMask {} damage immune {}", uint32(damageSchoolMask), victim->IsImmunedToDamage(spellInfo, damageSchoolMask));
     // Damage immunity is only checked if the spell has damage effects, this immunity must not prevent aura apply
     // returns SPELL_MISS_IMMUNE in that case, for other spells, the SMSG_SPELL_GO must show hit
     if (spellInfo->HasOnlyDamageEffects() && victim->IsImmunedToDamage(spellInfo, damageSchoolMask))
@@ -2704,7 +2704,7 @@ SpellMissInfo WorldObject::SpellHitResult(Unit* victim, SpellInfo const* spellIn
     if (canReflect)
     {
         int32 reflectchance = victim->GetTotalAuraModifier(SPELL_AURA_REFLECT_SPELLS);
-        reflectchance += victim->GetTotalAuraModifierByMiscMask(SPELL_AURA_REFLECT_SPELLS_SCHOOL, spellInfo->GetSchoolMask());
+        reflectchance += victim->GetTotalAuraModifierByMiscMask(SPELL_AURA_REFLECT_SPELLS_SCHOOL, damageSchoolMask);
         // @tswow-begin
         FIRE_ID(
               spellInfo->events.id

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2676,15 +2676,18 @@ SpellMissInfo WorldObject::MagicSpellHitResult(Unit* victim, SpellInfo const* sp
 //   Resist
 SpellMissInfo WorldObject::SpellHitResult(Unit* victim, SpellInfo const* spellInfo, bool canReflect /*= false*/) const
 {
+    TC_LOG_DEBUG("immunity", "WorldObject::SpellHitResult checking for spell immune {}", victim->IsImmunedToSpell(spellInfo, this));
     // Check for immune
     if (victim->IsImmunedToSpell(spellInfo, this))
         return SPELL_MISS_IMMUNE;
 
+    TC_LOG_DEBUG("immunity", "WorldObject::SpellHitResult checking for damage immune {}", victim->IsImmunedToDamage(spellInfo));
     // Damage immunity is only checked if the spell has damage effects, this immunity must not prevent aura apply
     // returns SPELL_MISS_IMMUNE in that case, for other spells, the SMSG_SPELL_GO must show hit
     if (spellInfo->HasOnlyDamageEffects() && victim->IsImmunedToDamage(spellInfo))
         return SPELL_MISS_IMMUNE;
 
+    TC_LOG_DEBUG("immunity", "WorldObject::SpellHitResult passed immunes");
     // All positive spells can`t miss
     /// @todo client not show miss log for this spells - so need find info for this in dbc and use it!
     if (spellInfo->IsPositive() && !IsHostileTo(victim)) // prevent from affecting enemy by "positive" spell

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -486,7 +486,7 @@ class TC_GAME_API WorldObject : public Object, public WorldLocation
         virtual float MeleeSpellMissChance(Unit const* victim, WeaponAttackType attType, int32 skillDiff, uint32 spellId) const;
         virtual SpellMissInfo MeleeSpellHitResult(Unit* victim, SpellInfo const* spellInfo) const;
         SpellMissInfo MagicSpellHitResult(Unit* victim, SpellInfo const* spellInfo) const;
-        SpellMissInfo SpellHitResult(Unit* victim, SpellInfo const* spellInfo, bool canReflect = false) const;
+        SpellMissInfo SpellHitResult(Unit* victim, SpellInfo const* spellInfo, SpellSchoolMask damageSchoolMask, bool canReflect = false) const;
         void SendSpellMiss(Unit* target, uint32 spellID, SpellMissInfo missInfo);
 
         virtual uint32 GetFaction() const = 0;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8173,7 +8173,7 @@ bool Unit::IsImmunedToDamage(SpellInfo const* spellInfo, SpellSchoolMask damageS
     return false;
 }
 
-bool Unit::IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* caster, bool requireImmunityPurgesEffectAttribute /*= false*/) const
+bool Unit::IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* caster, SpellSchoolMask damageSchoolMask /*= SPELL_SCHOOL_MASK_NONE*/, bool requireImmunityPurgesEffectAttribute /*= false*/) const
 {
     if (!spellInfo)
         return false;
@@ -8235,7 +8235,10 @@ bool Unit::IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* caste
     if (immuneToAllEffects) //Return immune only if the target is immune to all spell effects.
         return true;
 
-    if (uint32 schoolMask = spellInfo->GetSchoolMask())
+    if (damageSchoolMask == SPELL_SCHOOL_MASK_NONE)
+        damageSchoolMask = spellInfo->GetSchoolMask();
+
+    if (uint32 schoolMask = damageSchoolMask)
     {
         uint32 schoolImmunityMask = 0;
         SpellImmuneContainer const& schoolList = m_spellImmune[IMMUNITY_SCHOOL];

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1628,7 +1628,7 @@ void Unit::DealMeleeDamage(CalcDamageInfo* damageInfo, bool durabilityLoss)
             SpellInfo const* spellInfo = aurEff->GetSpellInfo();
 
             // Damage shield can be resisted...
-            SpellMissInfo missInfo = victim->SpellHitResult(this, spellInfo, false);
+            SpellMissInfo missInfo = victim->SpellHitResult(this, spellInfo, spellInfo->GetSchoolMask(), false);
             if (missInfo != SPELL_MISS_NONE)
             {
                 victim->SendSpellMiss(this, spellInfo->Id, missInfo);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8173,7 +8173,7 @@ bool Unit::IsImmunedToDamage(SpellInfo const* spellInfo, SpellSchoolMask damageS
     return false;
 }
 
-bool Unit::IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* caster, SpellSchoolMask damageSchoolMask /*= SPELL_SCHOOL_MASK_NONE*/, bool requireImmunityPurgesEffectAttribute /*= false*/) const
+bool Unit::IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* caster, bool requireImmunityPurgesEffectAttribute /*= false*/, SpellSchoolMask damageSchoolMask /*= SPELL_SCHOOL_MASK_NONE*/) const
 {
     if (!spellInfo)
         return false;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1741,7 +1741,7 @@ class TC_GAME_API Unit : public WorldObject
         float CalculateDefaultCoefficient(SpellInfo const* spellInfo, DamageEffectType damagetype) const;
 
         void ApplySpellImmune(uint32 spellId, uint32 op, uint32 type, bool apply);
-        virtual bool IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* caster, SpellSchoolMask damageSchoolMask = SPELL_SCHOOL_MASK_NONE, bool requireImmunityPurgesEffectAttribute = false) const;
+        virtual bool IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* caster, bool requireImmunityPurgesEffectAttribute = false, SpellSchoolMask damageSchoolMask = SPELL_SCHOOL_MASK_NONE) const;
         uint32 GetSchoolImmunityMask() const;
         uint32 GetDamageImmunityMask() const;
         uint32 GetMechanicImmunityMask() const;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1741,7 +1741,7 @@ class TC_GAME_API Unit : public WorldObject
         float CalculateDefaultCoefficient(SpellInfo const* spellInfo, DamageEffectType damagetype) const;
 
         void ApplySpellImmune(uint32 spellId, uint32 op, uint32 type, bool apply);
-        virtual bool IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* caster, bool requireImmunityPurgesEffectAttribute = false) const;
+        virtual bool IsImmunedToSpell(SpellInfo const* spellInfo, WorldObject const* caster, SpellSchoolMask damageSchoolMask = SPELL_SCHOOL_MASK_NONE, bool requireImmunityPurgesEffectAttribute = false) const;
         uint32 GetSchoolImmunityMask() const;
         uint32 GetDamageImmunityMask() const;
         uint32 GetMechanicImmunityMask() const;

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5180,7 +5180,7 @@ void AuraEffect::HandlePeriodicDamageAurasTick(Unit* target, Unit* caster) const
     // Consecrate ticks can miss and will not show up in the combat log
     // dynobj auras must always have a caster
     if (GetSpellEffectInfo().IsEffect(SPELL_EFFECT_PERSISTENT_AREA_AURA) &&
-        ASSERT_NOTNULL(caster)->SpellHitResult(target, GetSpellInfo(), false) != SPELL_MISS_NONE)
+        ASSERT_NOTNULL(caster)->SpellHitResult(target, GetSpellInfo(), GetSpellInfo()->GetSchoolMask(), false) != SPELL_MISS_NONE)
         return;
 
     CleanDamage cleanDamage = CleanDamage(0, 0, BASE_ATTACK, MELEE_HIT_NORMAL);
@@ -5309,7 +5309,7 @@ void AuraEffect::HandlePeriodicHealthLeechAuraTick(Unit* target, Unit* caster) c
 
     // dynobj auras must always have a caster
     if (GetSpellEffectInfo().IsEffect(SPELL_EFFECT_PERSISTENT_AREA_AURA) &&
-        ASSERT_NOTNULL(caster)->SpellHitResult(target, GetSpellInfo(), false) != SPELL_MISS_NONE)
+        ASSERT_NOTNULL(caster)->SpellHitResult(target, GetSpellInfo(), GetSpellInfo()->GetSchoolMask(), false) != SPELL_MISS_NONE)
         return;
 
     CleanDamage cleanDamage = CleanDamage(0, 0, GetSpellInfo()->GetAttackType(), MELEE_HIT_NORMAL);
@@ -5533,7 +5533,7 @@ void AuraEffect::HandlePeriodicManaLeechAuraTick(Unit* target, Unit* caster) con
     }
 
     if (GetSpellEffectInfo().Effect == SPELL_EFFECT_PERSISTENT_AREA_AURA &&
-        caster->SpellHitResult(target, GetSpellInfo(), false) != SPELL_MISS_NONE)
+        caster->SpellHitResult(target, GetSpellInfo(), GetSpellInfo()->GetSchoolMask(), false) != SPELL_MISS_NONE)
         return;
 
     // ignore negative values (can be result apply spellmods to aura damage

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -650,7 +650,7 @@ void Aura::UpdateTargetMap(Unit* caster, bool apply)
         {
             // needs readding - remove now, will be applied in next update cycle
             // (dbcs do not have auras which apply on same type of targets but have different radius, so this is not really needed)
-            if (itr->first->IsImmunedToSpell(GetSpellInfo(), caster, GetSpellInfo()->GetSchoolMask(), true) || !CanBeAppliedOn(itr->first))
+            if (itr->first->IsImmunedToSpell(GetSpellInfo(), caster, true) || !CanBeAppliedOn(itr->first))
             {
                 targetsToRemove.push_back(applicationPair.second->GetTarget());
                 continue;

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -650,7 +650,7 @@ void Aura::UpdateTargetMap(Unit* caster, bool apply)
         {
             // needs readding - remove now, will be applied in next update cycle
             // (dbcs do not have auras which apply on same type of targets but have different radius, so this is not really needed)
-            if (itr->first->IsImmunedToSpell(GetSpellInfo(), caster, true) || !CanBeAppliedOn(itr->first))
+            if (itr->first->IsImmunedToSpell(GetSpellInfo(), caster, GetSpellInfo()->GetSchoolMask(), true) || !CanBeAppliedOn(itr->first))
             {
                 targetsToRemove.push_back(applicationPair.second->GetTarget());
                 continue;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2590,8 +2590,9 @@ void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
             // Fill base damage struct (unitTarget - is real spell target)
             SpellNonMeleeDamage damageInfo(caster, spell->unitTarget, spell->m_spellInfo->Id, damageSchoolMask);
             // Check damage immunity
-            if (spell->unitTarget->IsImmunedToDamage(spell->m_spellInfo))
+            if (spell->unitTarget->IsImmunedToDamage(spell->m_spellInfo, damageSchoolMask))
             {
+                TC_LOG_DEBUG("spellimmune", "Target is immune to spell damage so DO NOT set last damage target guid");
                 hitMask = PROC_HIT_IMMUNE;
                 spell->m_damage = 0;
 
@@ -2599,6 +2600,7 @@ void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
             }
             else
             {
+                TC_LOG_DEBUG("spellimmune", "Target is not immune to spell damage so set last damage target guid");
                 caster->SetLastDamagedTargetGuid(spell->unitTarget->GetGUID());
 
                 // Add bonuses and fill damageInfo struct
@@ -2807,7 +2809,7 @@ SpellMissInfo Spell::PreprocessSpellHit(Unit* unit, bool scaleAura, TargetInfo& 
             return SPELL_MISS_EVADE;
 
     SpellSchoolMask damageSchoolMask = GetDamageSchoolMask();
-    if (m_spellInfo->Speed && ((m_damage > 0 && unit->IsImmunedToDamage(m_spellInfo, damageSchoolMask) || unit->IsImmunedToDamage(damageSchoolMask) || unit->IsImmunedToSpell(m_spellInfo, m_caster))))
+    if (m_spellInfo->Speed && ((m_damage > 0 && unit->IsImmunedToDamage(m_spellInfo, damageSchoolMask) || unit->IsImmunedToSpell(m_spellInfo, m_caster))))
         return SPELL_MISS_IMMUNE;
 
     if (Player* player = unit->ToPlayer())

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2807,7 +2807,7 @@ SpellMissInfo Spell::PreprocessSpellHit(Unit* unit, bool scaleAura, TargetInfo& 
             return SPELL_MISS_EVADE;
 
     SpellSchoolMask damageSchoolMask = GetDamageSchoolMask();
-    if (m_spellInfo->Speed && unit->IsImmunedToSpell(m_spellInfo, m_caster, damageSchoolMask))
+    if (m_spellInfo->Speed && unit->IsImmunedToSpell(m_spellInfo, m_caster, false, damageSchoolMask))
         return SPELL_MISS_IMMUNE;
 
     if (Player* player = unit->ToPlayer())

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2152,6 +2152,7 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
             effectMask &= ~(1 << spellEffectInfo.EffectIndex);
 
     ObjectGuid targetGUID = target->GetGUID();
+    
     // Lookup target in already in list
     auto ihit = std::find_if(std::begin(m_UniqueTargetInfo), std::end(m_UniqueTargetInfo), [targetGUID](TargetInfo const& target) { return target.TargetGUID == targetGUID; });
     if (ihit != std::end(m_UniqueTargetInfo)) // Found in list
@@ -2188,7 +2189,6 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
 
     // Calculate hit result
     WorldObject* caster = m_originalCaster ? m_originalCaster : m_caster;
-
     targetInfo.MissCondition = caster->SpellHitResult(target, m_spellInfo, m_damageSchoolMask, m_canReflect && !(IsPositive() && m_caster->IsFriendlyTo(target)));
 
     // @tswow-begin

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -521,6 +521,16 @@ m_caster((info->HasAttribute(SPELL_ATTR6_CAST_BY_CHARMER) && caster->GetCharmerO
 
     m_attackType = info->GetAttackType();
 
+    m_damageSchoolMask = info->GetSchoolMask();           // Can be override for some spell (wand shoot for example)
+
+    if (Player const* playerCaster = m_caster->ToPlayer())
+    {
+        // wand/bow/gun shoot/auto attack. these spells are effectively auto attacks and should use the weapon's damage type
+        if (m_spellInfo->Id == 75 || m_spellInfo->Id == 3018 || m_spellInfo->Id == 5019)
+            if (Item* pItem = playerCaster->GetWeaponForAttack(RANGED_ATTACK))
+                m_damageSchoolMask = SpellSchoolMask(1 << pItem->GetTemplate()->Damage[0].DamageType);
+    }
+
     if (originalCasterGUID)
         m_originalCasterGUID = originalCasterGUID;
     else
@@ -617,19 +627,6 @@ Spell::~Spell()
 
     // missing cleanup somewhere, mem leaks so let's crash
     AssertEffectExecuteData();
-}
-
-// Returns the school mask to use for final spell damage
-SpellSchoolMask Spell::GetDamageSchoolMask() const
-{
-    if (Player const* playerCaster = m_caster->ToPlayer())
-    {
-        // wand/bow/gun shoot/auto attack.  these spells are effectively auto attacks and should use the weapons primary damage type
-        if (m_spellInfo->Id == 75 || m_spellInfo->Id == 3018 || m_spellInfo->Id == 5019)
-            if (Item* pItem = playerCaster->GetWeaponForAttack(RANGED_ATTACK))
-                return SpellSchoolMask(1 << pItem->GetTemplate()->Damage[0].DamageType);
-    }
-    return m_spellInfo->GetSchoolMask();
 }
 
 void Spell::InitExplicitTargets(SpellCastTargets const& targets)
@@ -1021,7 +1018,7 @@ void Spell::SelectImplicitChannelTargets(SpellEffectInfo const& spellEffectInfo,
         {
             WorldObject* target = ObjectAccessor::GetUnit(*m_caster, m_originalCaster->GetChannelObjectGuid());
             CallScriptObjectTargetSelectHandlers(target, spellEffectInfo.EffectIndex, targetType);
-            // unit target may be no longer avalible - teleported out of map for example
+            // unit target may be no longer available - teleported out of map for example
             if (target && target->ToUnit())
                 AddUnitTarget(target->ToUnit(), effMask);
             else
@@ -2155,7 +2152,6 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
             effectMask &= ~(1 << spellEffectInfo.EffectIndex);
 
     ObjectGuid targetGUID = target->GetGUID();
-
     // Lookup target in already in list
     auto ihit = std::find_if(std::begin(m_UniqueTargetInfo), std::end(m_UniqueTargetInfo), [targetGUID](TargetInfo const& target) { return target.TargetGUID == targetGUID; });
     if (ihit != std::end(m_UniqueTargetInfo)) // Found in list
@@ -2192,8 +2188,9 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
 
     // Calculate hit result
     WorldObject* caster = m_originalCaster ? m_originalCaster : m_caster;
+
     TC_LOG_DEBUG("immunity", "Spell::AddUnitTarget setting target info MissCondition from SpellHitResult");
-    targetInfo.MissCondition = caster->SpellHitResult(target, m_spellInfo, m_canReflect && !(IsPositive() && m_caster->IsFriendlyTo(target)));
+    targetInfo.MissCondition = caster->SpellHitResult(target, m_spellInfo, m_damageSchoolMask, m_canReflect && !(IsPositive() && m_caster->IsFriendlyTo(target)));
 
     // @tswow-begin
     uint32 miss = targetInfo.MissCondition;
@@ -2239,7 +2236,7 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
         // Calculate reflected spell result on caster
         SpellCastResult castResult = m_spellInfo->CheckTarget(target, unitCaster, implicit);
         if (castResult == SPELL_CAST_OK || castResult == SPELL_FAILED_TARGET_AURASTATE)
-            targetInfo.ReflectResult = unitCaster->SpellHitResult(unitCaster, m_spellInfo, false); // can't reflect twice
+            targetInfo.ReflectResult = unitCaster->SpellHitResult(unitCaster, m_spellInfo, m_damageSchoolMask, false); // can't reflect twice
         else
             targetInfo.ReflectResult = SPELL_MISS_IMMUNE;
 
@@ -2584,15 +2581,14 @@ void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
 
         // Do damage
         bool hasDamage = false;
-        SpellSchoolMask damageSchoolMask = spell->GetDamageSchoolMask();
         if (spell->m_damage > 0)
         {
             hasDamage = true;
             // Fill base damage struct (unitTarget - is real spell target)
-            SpellNonMeleeDamage damageInfo(caster, spell->unitTarget, spell->m_spellInfo->Id, damageSchoolMask);
+            SpellNonMeleeDamage damageInfo(caster, spell->unitTarget, spell->m_spellInfo->Id, spell->GetDamageSchoolMask());
             // Check damage immunity
-            TC_LOG_DEBUG("immunity", "Spell::TargetInfo::DoDamageAndTriggers DamageSchoolMask {} and IsImmunedToDamage? {}", uint8(damageSchoolMask), spell->unitTarget->IsImmunedToDamage(spell->m_spellInfo, damageSchoolMask));
-            if (spell->unitTarget->IsImmunedToDamage(spell->m_spellInfo, damageSchoolMask))
+            TC_LOG_DEBUG("immunity", "Spell::TargetInfo::DoDamageAndTriggers DamageSchoolMask {} and IsImmunedToDamage? {}", uint8(spell->GetDamageSchoolMask()), spell->unitTarget->IsImmunedToDamage(spell->m_spellInfo, spell->GetDamageSchoolMask()));
+            if (spell->unitTarget->IsImmunedToDamage(spell->m_spellInfo, spell->GetDamageSchoolMask()))
             {
                 hitMask = PROC_HIT_IMMUNE;
                 spell->m_damage = 0;
@@ -2629,7 +2625,7 @@ void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
         if (!hasHealing && !hasDamage)
         {
             // Fill base damage struct (unitTarget - is real spell target)
-            SpellNonMeleeDamage damageInfo(caster, spell->unitTarget, spell->m_spellInfo->Id, damageSchoolMask);
+            SpellNonMeleeDamage damageInfo(caster, spell->unitTarget, spell->m_spellInfo->Id, spell->GetDamageSchoolMask());
             hitMask |= createProcHitMask(&damageInfo, MissCondition);
             // Do triggers for unit
             if (canEffectTrigger)
@@ -2808,9 +2804,8 @@ SpellMissInfo Spell::PreprocessSpellHit(Unit* unit, bool scaleAura, TargetInfo& 
         if (creatureTarget->IsEvadingAttacks())
             return SPELL_MISS_EVADE;
 
-    SpellSchoolMask damageSchoolMask = GetDamageSchoolMask();
-    TC_LOG_DEBUG("immunity", "Spell::PreprocessSpellHit Speed {} and DamageSchoolMask {} and ImmunedToSpell? {}", m_spellInfo->Speed, uint8(damageSchoolMask), unit->IsImmunedToSpell(m_spellInfo, m_caster, false, damageSchoolMask));
-    if (m_spellInfo->Speed && unit->IsImmunedToSpell(m_spellInfo, m_caster, false, damageSchoolMask))
+    TC_LOG_DEBUG("immunity", "Spell::PreprocessSpellHit Speed {} and DamageSchoolMask {} and ImmunedToSpell? {}", m_spellInfo->Speed, uint8(m_damageSchoolMask), unit->IsImmunedToSpell(m_spellInfo, m_caster, false, m_damageSchoolMask));
+    if (m_spellInfo->Speed && unit->IsImmunedToSpell(m_spellInfo, m_caster, false, m_damageSchoolMask))
         return SPELL_MISS_IMMUNE;
 
     if (Player* player = unit->ToPlayer())

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2592,7 +2592,6 @@ void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
             // Check damage immunity
             if (spell->unitTarget->IsImmunedToDamage(spell->m_spellInfo, damageSchoolMask))
             {
-                TC_LOG_DEBUG("spellimmune", "Target is immune to spell damage so DO NOT set last damage target guid");
                 hitMask = PROC_HIT_IMMUNE;
                 spell->m_damage = 0;
 
@@ -2600,7 +2599,6 @@ void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
             }
             else
             {
-                TC_LOG_DEBUG("spellimmune", "Target is not immune to spell damage so set last damage target guid");
                 caster->SetLastDamagedTargetGuid(spell->unitTarget->GetGUID());
 
                 // Add bonuses and fill damageInfo struct

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2806,7 +2806,8 @@ SpellMissInfo Spell::PreprocessSpellHit(Unit* unit, bool scaleAura, TargetInfo& 
         if (creatureTarget->IsEvadingAttacks())
             return SPELL_MISS_EVADE;
 
-    if (m_spellInfo->Speed && unit->IsImmunedToSpell(m_spellInfo, m_caster))
+    SpellSchoolMask damageSchoolMask = GetDamageSchoolMask();
+    if (m_spellInfo->Speed && unit->IsImmunedToSpell(m_spellInfo, m_caster, damageSchoolMask))
         return SPELL_MISS_IMMUNE;
 
     if (Player* player = unit->ToPlayer())

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2152,7 +2152,7 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
             effectMask &= ~(1 << spellEffectInfo.EffectIndex);
 
     ObjectGuid targetGUID = target->GetGUID();
-    
+
     // Lookup target in already in list
     auto ihit = std::find_if(std::begin(m_UniqueTargetInfo), std::end(m_UniqueTargetInfo), [targetGUID](TargetInfo const& target) { return target.TargetGUID == targetGUID; });
     if (ihit != std::end(m_UniqueTargetInfo)) // Found in list

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2806,8 +2806,7 @@ SpellMissInfo Spell::PreprocessSpellHit(Unit* unit, bool scaleAura, TargetInfo& 
         if (creatureTarget->IsEvadingAttacks())
             return SPELL_MISS_EVADE;
 
-    SpellSchoolMask damageSchoolMask = GetDamageSchoolMask();
-    if (m_spellInfo->Speed && ((m_damage > 0 && unit->IsImmunedToDamage(m_spellInfo, damageSchoolMask) || unit->IsImmunedToSpell(m_spellInfo, m_caster))))
+    if (m_spellInfo->Speed && unit->IsImmunedToSpell(m_spellInfo, m_caster))
         return SPELL_MISS_IMMUNE;
 
     if (Player* player = unit->ToPlayer())

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2189,7 +2189,6 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
     // Calculate hit result
     WorldObject* caster = m_originalCaster ? m_originalCaster : m_caster;
 
-    TC_LOG_DEBUG("immunity", "Spell::AddUnitTarget setting target info MissCondition from SpellHitResult");
     targetInfo.MissCondition = caster->SpellHitResult(target, m_spellInfo, m_damageSchoolMask, m_canReflect && !(IsPositive() && m_caster->IsFriendlyTo(target)));
 
     // @tswow-begin
@@ -2587,7 +2586,6 @@ void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
             // Fill base damage struct (unitTarget - is real spell target)
             SpellNonMeleeDamage damageInfo(caster, spell->unitTarget, spell->m_spellInfo->Id, spell->GetDamageSchoolMask());
             // Check damage immunity
-            TC_LOG_DEBUG("immunity", "Spell::TargetInfo::DoDamageAndTriggers DamageSchoolMask {} and IsImmunedToDamage? {}", uint8(spell->GetDamageSchoolMask()), spell->unitTarget->IsImmunedToDamage(spell->m_spellInfo, spell->GetDamageSchoolMask()));
             if (spell->unitTarget->IsImmunedToDamage(spell->m_spellInfo, spell->GetDamageSchoolMask()))
             {
                 hitMask = PROC_HIT_IMMUNE;
@@ -2804,7 +2802,6 @@ SpellMissInfo Spell::PreprocessSpellHit(Unit* unit, bool scaleAura, TargetInfo& 
         if (creatureTarget->IsEvadingAttacks())
             return SPELL_MISS_EVADE;
 
-    TC_LOG_DEBUG("immunity", "Spell::PreprocessSpellHit Speed {} and DamageSchoolMask {} and ImmunedToSpell? {}", m_spellInfo->Speed, uint8(m_damageSchoolMask), unit->IsImmunedToSpell(m_spellInfo, m_caster, false, m_damageSchoolMask));
     if (m_spellInfo->Speed && unit->IsImmunedToSpell(m_spellInfo, m_caster, false, m_damageSchoolMask))
         return SPELL_MISS_IMMUNE;
 

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2192,6 +2192,7 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
 
     // Calculate hit result
     WorldObject* caster = m_originalCaster ? m_originalCaster : m_caster;
+    TC_LOG_DEBUG("immunity", "Spell::AddUnitTarget setting target info MissCondition from SpellHitResult");
     targetInfo.MissCondition = caster->SpellHitResult(target, m_spellInfo, m_canReflect && !(IsPositive() && m_caster->IsFriendlyTo(target)));
 
     // @tswow-begin
@@ -2590,6 +2591,7 @@ void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
             // Fill base damage struct (unitTarget - is real spell target)
             SpellNonMeleeDamage damageInfo(caster, spell->unitTarget, spell->m_spellInfo->Id, damageSchoolMask);
             // Check damage immunity
+            TC_LOG_DEBUG("immunity", "Spell::TargetInfo::DoDamageAndTriggers DamageSchoolMask {} and IsImmunedToDamage? {}", uint8(damageSchoolMask), spell->unitTarget->IsImmunedToDamage(spell->m_spellInfo, damageSchoolMask));
             if (spell->unitTarget->IsImmunedToDamage(spell->m_spellInfo, damageSchoolMask))
             {
                 hitMask = PROC_HIT_IMMUNE;
@@ -2807,6 +2809,7 @@ SpellMissInfo Spell::PreprocessSpellHit(Unit* unit, bool scaleAura, TargetInfo& 
             return SPELL_MISS_EVADE;
 
     SpellSchoolMask damageSchoolMask = GetDamageSchoolMask();
+    TC_LOG_DEBUG("immunity", "Spell::PreprocessSpellHit Speed {} and DamageSchoolMask {} and ImmunedToSpell? {}", m_spellInfo->Speed, uint8(damageSchoolMask), unit->IsImmunedToSpell(m_spellInfo, m_caster, false, damageSchoolMask));
     if (m_spellInfo->Speed && unit->IsImmunedToSpell(m_spellInfo, m_caster, false, damageSchoolMask))
         return SPELL_MISS_IMMUNE;
 

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -300,7 +300,6 @@ class TC_GAME_API Spell
         Spell(WorldObject* caster, SpellInfo const* info, TriggerCastFlags triggerFlags, ObjectGuid originalCasterGUID = ObjectGuid::Empty);
         ~Spell();
 
-        SpellSchoolMask GetDamageSchoolMask() const;
         void InitExplicitTargets(SpellCastTargets const& targets);
         void SelectExplicitTargets();
 
@@ -412,6 +411,7 @@ class TC_GAME_API Spell
         void HandleThreatSpells();
 
         SpellInfo const* const m_spellInfo;
+        SpellSchoolMask m_damageSchoolMask;
         Item* m_CastItem;
         ObjectGuid m_castItemGUID;
         uint32 m_castItemEntry;
@@ -473,6 +473,7 @@ class TC_GAME_API Spell
         WorldObject* GetCaster() const { return m_caster; }
         Unit* GetOriginalCaster() const { return m_originalCaster; }
         SpellInfo const* GetSpellInfo() const { return m_spellInfo; }
+        SpellSchoolMask GetDamageSchoolMask() const { return m_damageSchoolMask; }
         int32 GetPowerCost() const { return m_powerCost; }
 
         bool UpdatePointers();                              // must be used at call Spell code after time delay (non triggered spell cast/update spell call/etc)


### PR DESCRIPTION
Add damage school to IsImmunedToSpell rather than invoking IsImmunedToDamage from PreprocessSpellHit
