### PR TITLE
Try again to add the owner of a pet or charmed unit on the threat lis…

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3643,6 +3643,9 @@ void Creature::AtEngage(Unit* target)
         // @tswow-end
     }
 
+    if (Unit* targetOwner = target->GetCharmerOrOwner())
+        EngageWithTarget(targetOwner);
+
     if (CreatureAI* ai = AI())
         ai->JustEngagedWith(target);
     // @tswow-begin custom boss check

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8776,6 +8776,9 @@ void Unit::EngageWithTarget(Unit* enemy)
     // Maybe there is a better place for it.
     if (Creature* pCreature = ToCreature())
         pCreature->UpdateLeashExtensionTime();
+
+    if (Unit* enemyOwner = enemy->GetCharmerOrOwner())
+        EngageWithTarget(enemyOwner);
 }
 
 void Unit::SetImmuneToAll(bool apply, bool keepCombat)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8776,9 +8776,6 @@ void Unit::EngageWithTarget(Unit* enemy)
     // Maybe there is a better place for it.
     if (Creature* pCreature = ToCreature())
         pCreature->UpdateLeashExtensionTime();
-
-    if (Unit* enemyOwner = enemy->GetCharmerOrOwner())
-        EngageWithTarget(enemyOwner);
 }
 
 void Unit::SetImmuneToAll(bool apply, bool keepCombat)


### PR DESCRIPTION
…t of a creature.

Still recursive, hopefully safer and no silent server crashes X_X.

Use the higher level EngageWithTarget() function instead of meddling in low-level AddThreat recursive calls.

I'm not sure whether there is a better place for it, and I'm also not sure what's the responsibility of the Creature/Unit classes vs AI class when it comes to combat interaction

Potential candidates...? AtEngage(), JustEnteredCombat(), OnEnterCombat() (although it doesn't have an enemy attached to it).. Maybe ulmetrs has a better idea...