### PR TITLE
Cast Skill Spell new achievement criteria

### DIFF
--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -857,6 +857,9 @@ void AchievementMgr::UpdateAchievementCriteria(AchievementCriteriaTypes type, ui
             // @tswow-begin
             case ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_ENCOUNTER:
             // @tswow-end
+            // @epoch-begin
+            case ACHIEVEMENT_CRITERIA_TYPE_CAST_SKILL_SPELL:
+            // @epoch-end
                 SetCriteriaProgress(achievementCriteria, 1, PROGRESS_ACCUMULATE);
                 break;
             // std case: increment at miscvalue1
@@ -1239,6 +1242,9 @@ bool AchievementMgr::IsCompletedCriteria(AchievementCriteriaEntry const* achieve
         // @tswow-begin
         case ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_ENCOUNTER:
         // @tswow-end
+        // @epoch-begin
+        case ACHIEVEMENT_CRITERIA_TYPE_CAST_SKILL_SPELL:
+        // @epoch-end
             return progress->counter >= achievementCriteria->Quantity;
         case ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_ACHIEVEMENT:
         case ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST:

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5876,6 +5876,11 @@ bool Player::UpdateSkillPro(uint16 SkillId, int32 Chance, uint32 step)
     uint16 SkillValue = SKILL_VALUE(data);
     uint16 MaxValue   = SKILL_MAX(data);
 
+    /** @epoch-start */
+    // If the player is completing any level appropriate craft, update achievement criteria
+    UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_CAST_SKILL_SPELL, SkillId);
+    /** @epoch-end */
+
     if (!MaxValue || !SkillValue || SkillValue >= MaxValue)
         return false;
 

--- a/src/server/shared/DataStores/DBCEnums.h
+++ b/src/server/shared/DataStores/DBCEnums.h
@@ -235,6 +235,8 @@ enum AchievementCriteriaTypes : uint8
     ACHIEVEMENT_CRITERIA_TYPE_USE_LFD_TO_GROUP_WITH_PLAYERS = 119,
     // @tswow-begin custom achievement criteria
     ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_ENCOUNTER            = 120,
+    // @epoch-begin custom achievement criteria
+    ACHIEVEMENT_CRITERIA_TYPE_CAST_SKILL_SPELL              = 121,
 };
 
 #define ACHIEVEMENT_CRITERIA_TYPE_TOTAL 124

--- a/src/server/shared/DataStores/DBCStructure.h
+++ b/src/server/shared/DataStores/DBCStructure.h
@@ -72,6 +72,9 @@ struct AchievementCriteriaEntry
         // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LEVEL      = 40
         // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILLLINE_SPELLS = 75
         // ACHIEVEMENT_CRITERIA_TYPE_LEARN_SKILL_LINE       = 112
+        // @epoch-start
+        // ACHIEVEMENT_CRITERIA_TYPE_CAST_SKILL_SPELL       = 121
+        // @epoch-end
         uint32 SkillID;
 
         // ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_ACHIEVEMENT   = 8


### PR DESCRIPTION
Implements new achievement criteria type called Cast Skill Spell, which gives you credit when you cast a spell that grants a skillup from the chosen skill.