### PR TITLE
Use custom animations for gobjects which have them (mainly hunter

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -742,6 +742,8 @@ void GameObject::Update(uint32 diff)
                     if (target)
                         SetLootState(GO_ACTIVATED, target);
 
+                    if (HasCustomAnim())
+                        SendCustomAnim(0);
                 }
                 else if (uint32 max_charges = goInfo->GetCharges())
                 {
@@ -1715,6 +1717,9 @@ void GameObject::Use(Unit* user)
 
             m_cooldownTime = GameTime::GetGameTimeMS() + (goInfo->trap.cooldown ? goInfo->trap.cooldown : uint32(4)) * IN_MILLISECONDS;   // template or 4 seconds
 
+            if (HasCustomAnim())
+                SendCustomAnim(0);
+
             if (goInfo->trap.type == 1)         // Deactivate after trigger
                 SetLootState(GO_JUST_DEACTIVATED);
 
@@ -2307,6 +2312,27 @@ void GameObject::Use(Unit* user)
     else
         CastSpell(target, spellId);
     // @tswow-end
+}
+
+bool GameObject::HasCustomAnim() const
+{
+    switch (GetDisplayId())
+    {
+        case 2570: // eternal flame
+        case 3071: // freezing trap
+        case 3072: // explosive trap
+        case 3073: // frost trap, fixed trap
+        case 3074: // immolation trap
+        case 4392: // lava fissure
+        case 4472: // lava fissure
+        case 4491: // mortar in dun morogh
+        case 6785: // plague fissure
+        case 6747: // sapphiron birth
+        case 6871: // Silithyst bring in
+            return true;
+    }
+
+    return false;
 }
 
 void GameObject::SendCustomAnim(uint32 anim)

--- a/src/server/game/Entities/GameObject/GameObject.h
+++ b/src/server/game/Entities/GameObject/GameObject.h
@@ -264,6 +264,7 @@ class TC_GAME_API GameObject : public WorldObject, public GridObject<GameObject>
 
         GameObject* LookupFishingHoleAround(float range);
 
+        bool HasCustomAnim() const;
         void SendCustomAnim(uint32 anim);
         bool IsInRange(float x, float y, float z, float radius) const;
 


### PR DESCRIPTION
traps)

Based on vmangos commit https://github.com/vmangos/core/commit/c99acdba8e4cfae0723ee6525bd378d822d16cfe

I copied all the cases they had in the function (which seem to include onyxia lava fissures). If any of them break something up in your custom scripts you can comment them out.

Should be purely cosmetic.