### PR TITLE
Revert tagging to pre-WotLK behaviour.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9325,9 +9325,9 @@ void Unit::AtTargetAttacked(Unit* target, bool canInitialAggro)
         targetOwner->EngageWithTarget(this);
 
     //Patch 3.0.8: All player spells which cause a creature to become aggressive to you will now also immediately cause the creature to be tapped.
-    if (Creature* creature = target->ToCreature())
-        if (!creature->hasLootRecipient() && GetTypeId() == TYPEID_PLAYER)
-            creature->SetLootRecipient(this);
+    // if (Creature* creature = target->ToCreature())
+    //     if (!creature->hasLootRecipient() && GetTypeId() == TYPEID_PLAYER)
+    //         creature->SetLootRecipient(this);
 
     Player* myPlayerOwner = GetCharmerOrOwnerPlayerOrPlayerItself();
     Player* targetPlayerOwner = target->GetCharmerOrOwnerPlayerOrPlayerItself();


### PR DESCRIPTION
Applying DoTs and missing attacks should no longer tag the mob. You need to deal damage.
