### PR TITLE
Implement Auto Shot Queuing.

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -27636,6 +27636,27 @@ bool Player::CanExecutePendingSpellCastRequest(SpellInfo const* spellInfo, bool 
                 return false;
             }
         }
+
+    // For hunter Steady/Multi-Shot, we want to queue them after our auto shot
+    if ((spellInfo->SpellFamilyName == SPELLFAMILY_HUNTER) &&
+        ((spellInfo->SpellFamilyFlags[1] & 0x1) || // Steady Shot
+//        (spellInfo->SpellFamilyFlags[0] & 0x20000) || // Aimed Shot
+        (spellInfo->SpellFamilyFlags[0] & 0x1000))) // Multi-Shot
+    {
+        if (Spell *spell = GetCurrentSpell(CURRENT_AUTOREPEAT_SPELL))
+        {
+            if (spell->m_spellInfo->Id == 75) // Auto-Shot
+            {
+                if (isMoving()) // Need to cancel request otherwise it stays queued
+                {
+                    CancelPendingCastRequest(spellInfo->StartRecoveryCategory);
+                    return false;
+                }
+                if (getAttackTimer(RANGED_ATTACK) < 500) // Note: Might need to include haste later
+                    return false;
+            }
+        }
+    }
     TC_LOG_DEBUG("misc", "CanExecutePendingSpellCastRequest {}) returns true", !without_queue);
     return true;
 }


### PR DESCRIPTION
Allow Steady Shot and Multi-Shot to be queued after auto shot, bringing the mechanic in line with TBCC (and original TBC).

https://github.com/Project-Epoch/bugtracker/issues/8327
points 5 and 6.

Note: Even though the client will show GCD desync (it does so for any spell queued, not only hunter ones), the GCD gets calculated correctly server side, such that you won't be able to cast spells earlier than 1.5 sec (no haste) after that start of the cast.

Note 2: If you start moving to stop the queuing before the SS/Multi actually starts to cast, the GCD that is incurred will not be reset... seems more like a client limitation. Works the same way on stormforge 2.4.3, so if it's good enough for them it should be for us too. This is really an edge-case, since generally people start moving after their auto-shot goes off, so SS/Multi is no longer queuing and has instead started to cast; at this point when you move to interrupt the GCD clears successfully.

Tested on epoch-core with stock wotlk, hopefully it translates to Epoch as well.