### PR TITLE
Dynamic relocations perf

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1110,11 +1110,11 @@ void Creature::Update(uint32 diff)
     // For now, do this at the end of the update
     // For now, do this at the end of the update 
     float baseLineDiff = 300.0f; // A normal diff for an active server
-    float scaleFactor = std::min(std::max(p_time / baseLineDiff, 1.0f), 5.0f); // Diff scale 1x->5x
+    float scaleFactor = std::min(std::max(diff / baseLineDiff, 1.0f), 5.0f); // Diff scale 1x->5x
     uint32 scaledPeriod = GetMap()->GetVisibilityNotifyPeriod() * scaleFactor; 
     uint32 currentTime = GameTime::GetGameTimeMS();
     uint32 currentOffset = currentTime % scaledPeriod;
-    uint32 lastOffset = (currentTime - p_time) % scaledPeriod;
+    uint32 lastOffset = (currentTime - diff) % scaledPeriod;
     uint32 guidOffset = GetGUID().GetCounter() % scaledPeriod;
     // Check if guidOffset was crossed during this frame
     bool crossed = (lastOffset < currentOffset) ?

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1108,15 +1108,26 @@ void Creature::Update(uint32 diff)
     }
 
     // For now, do this at the end of the update
-    vis_Update.TUpdate(diff);
-    if (vis_Update.TPassed())
+    // For now, do this at the end of the update 
+    float baseLineDiff = 300.0f; // A normal diff for an active server
+    float scaleFactor = std::min(std::max(p_time / baseLineDiff, 1.0f), 5.0f); // Diff scale 1x->5x
+    uint32 scaledPeriod = GetMap()->GetVisibilityNotifyPeriod() * scaleFactor; 
+    uint32 currentTime = GameTime::GetGameTimeMS();
+    uint32 currentOffset = currentTime % scaledPeriod;
+    uint32 lastOffset = (currentTime - p_time) % scaledPeriod;
+    uint32 guidOffset = GetGUID().GetCounter() % scaledPeriod;
+    // Check if guidOffset was crossed during this frame
+    bool crossed = (lastOffset < currentOffset) ?
+        (guidOffset > lastOffset && guidOffset <= currentOffset) :
+        (guidOffset > lastOffset || guidOffset <= currentOffset);
+    if (crossed)
     {
-        vis_Update.TReset(diff, GetMap()->GetVisibilityNotifyPeriod());
-
         if (isNeedNotify(NOTIFY_VISIBILITY_CHANGED))
         {
             CreatureRelocationNotifier relocate(*this);
-            Cell::VisitAllObjects(this, relocate, 100, false);
+            // Scale range from full down to half based on scaleFactor (1x->5x becomes 1.0->0.5)
+            float rangeScale = 1.0f - ((scaleFactor - 1.0f) / 8.0f);
+            Cell::VisitAllObjects(this, relocate, GetMap()->GetVisibilityRange() * rangeScale, false);
         }
 
         ResetAllNotifies();

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1406,19 +1406,28 @@ void Player::Update(uint32 p_time)
     if (IsHasDelayedTeleport())
         TeleportTo(m_teleport_dest, m_teleport_options);
 
-    // For now, do this at the end of the update
-    // Periodically send player updated visibility of all surrounding units
-    vis_Update.TUpdate(p_time);
-    if (vis_Update.TPassed())
+    // For now, do this at the end of the update 
+    float baseLineDiff = 300.0f; // A normal diff for an active server
+    float scaleFactor = std::min(std::max(p_time / baseLineDiff, 1.0f), 5.0f); // Diff scale 1x->5x
+    uint32 scaledPeriod = GetMap()->GetVisibilityNotifyPeriod() * scaleFactor; 
+    uint32 currentTime = GameTime::GetGameTimeMS();
+    uint32 currentOffset = currentTime % scaledPeriod;
+    uint32 lastOffset = (currentTime - p_time) % scaledPeriod;
+    uint32 guidOffset = GetGUID().GetCounter() % scaledPeriod;
+    // Check if guidOffset was crossed during this frame
+    bool crossed = (lastOffset < currentOffset) ?
+        (guidOffset > lastOffset && guidOffset <= currentOffset) :
+        (guidOffset > lastOffset || guidOffset <= currentOffset);
+    if (crossed)
     {
-        vis_Update.TReset(p_time, GetMap()->GetVisibilityNotifyPeriod());
-
         WorldObject const* viewPoint = m_seer;
         if (viewPoint->isNeedNotify(NOTIFY_VISIBILITY_CHANGED) && (this == viewPoint || viewPoint->IsPositionValid()))
         {
             ZoneScopedN("Player::Update::RelocationNotifier")
             PlayerRelocationNotifier relocate(*this);
-            Cell::VisitAllObjects(viewPoint, relocate, 100, false);
+            // Scale range from full down to half based on scaleFactor (1x->5x becomes 1.0->0.5)
+            float rangeScale = 1.0f - ((scaleFactor - 1.0f) / 8.0f);
+            Cell::VisitAllObjects(viewPoint, relocate, GetMap()->GetVisibilityRange() * rangeScale, false);
             relocate.SendToSelf();
         }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1420,6 +1420,7 @@ void Player::Update(uint32 p_time)
         (guidOffset > lastOffset || guidOffset <= currentOffset);
     if (crossed)
     {
+        TC_LOG_DEBUG("testnotify", "SendNotify {}", GetGameTimeMS());
         WorldObject const* viewPoint = m_seer;
         if (viewPoint->isNeedNotify(NOTIFY_VISIBILITY_CHANGED) && (this == viewPoint || viewPoint->IsPositionValid()))
         {
@@ -1432,6 +1433,10 @@ void Player::Update(uint32 p_time)
         }
 
         ResetAllNotifies();
+    }
+    else
+    {
+        TC_LOG_DEBUG("testnotify", "NOT SendNotify {}", GetGameTimeMS());
     }
 }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1420,7 +1420,6 @@ void Player::Update(uint32 p_time)
         (guidOffset > lastOffset || guidOffset <= currentOffset);
     if (crossed)
     {
-        TC_LOG_DEBUG("testnotify", "SendNotify {}", currentTime);
         WorldObject const* viewPoint = m_seer;
         if (viewPoint->isNeedNotify(NOTIFY_VISIBILITY_CHANGED) && (this == viewPoint || viewPoint->IsPositionValid()))
         {
@@ -1433,10 +1432,6 @@ void Player::Update(uint32 p_time)
         }
 
         ResetAllNotifies();
-    }
-    else
-    {
-        TC_LOG_DEBUG("testnotify", "NOT SendNotify {}", currentTime);
     }
 }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1420,7 +1420,7 @@ void Player::Update(uint32 p_time)
         (guidOffset > lastOffset || guidOffset <= currentOffset);
     if (crossed)
     {
-        TC_LOG_DEBUG("testnotify", "SendNotify {}", GetGameTimeMS());
+        TC_LOG_DEBUG("testnotify", "SendNotify {}", currentTime);
         WorldObject const* viewPoint = m_seer;
         if (viewPoint->isNeedNotify(NOTIFY_VISIBILITY_CHANGED) && (this == viewPoint || viewPoint->IsPositionValid()))
         {
@@ -1436,7 +1436,7 @@ void Player::Update(uint32 p_time)
     }
     else
     {
-        TC_LOG_DEBUG("testnotify", "NOT SendNotify {}", GetGameTimeMS());
+        TC_LOG_DEBUG("testnotify", "NOT SendNotify {}", currentTime);
     }
 }
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -314,8 +314,7 @@ Unit::Unit(bool isWorldObject) :
     m_removedAurasCount(0), m_charmer(nullptr), m_charmed(nullptr),
     i_motionMaster(new MotionMaster(this)), m_regenTimer(0), m_vehicle(nullptr), m_vehicleKit(nullptr),
     m_unitTypeMask(UNIT_MASK_NONE), m_Diminishing(), m_combatManager(this), m_threatManager(this),
-    m_aiLocked(false), m_comboTarget(nullptr), m_comboPoints(0), _spellHistory(new SpellHistory(this)),
-    vis_Update(0, irand(0, DEFAULT_VISIBILITY_NOTIFY_PERIOD))
+    m_aiLocked(false), m_comboTarget(nullptr), m_comboPoints(0), _spellHistory(new SpellHistory(this))
 {
     m_objectType |= TYPEMASK_UNIT;
     m_objectTypeId = TYPEID_UNIT;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -2013,7 +2013,6 @@ class TC_GAME_API Unit : public WorldObject
 
         uint32 m_reactiveTimer[MAX_REACTIVE];
         uint32 m_regenTimer;
-        PeriodicTimer vis_Update;
 
         Vehicle* m_vehicle;
         Trinity::unique_trackable_ptr<Vehicle> m_vehicleKit;


### PR DESCRIPTION
Performance improvements for High diffs:

We will scale back the relocation notifies in two ways:

The default notify period is 1 second.  We use a baseline diff of 300ms.  We use a max threshold of 1500ms.
We get a scale factor of 1->5 as the diff scales from 300ms->1500ms, clamped.  meaning for diffs >= 1500 we will
have a notify period of 5 seconds, ensuring we do not send every single notify on every single frame.  If the diff > 5 seconds
this cannot be avoided and will fall off a cliff.

We also use this same diff range to scale back the notify distance from 100 yards -> 50 yards.

To ensure better distribution of notifies we switch to using the guid to determine whether an object will update - this should reduce the clustering of update timers and provide a more consistent distribution.