### PR TITLE
tracy freeze fix

### DIFF
--- a/src/server/authserver/Main.cpp
+++ b/src/server/authserver/Main.cpp
@@ -294,8 +294,16 @@ void StopDB()
     MySQL::Library_End();
 }
 
-void SignalHandler(std::weak_ptr<Trinity::Asio::IoContext> ioContextRef, boost::system::error_code const& error, int /*signalNumber*/)
+void SignalHandler(std::weak_ptr<Trinity::Asio::IoContext> ioContextRef, boost::system::error_code const& error, int signalNumber)
 {
+    if (error.failed())
+    {
+        TC_LOG_ERROR("server.authserver", "Received signal: {} and error: {}", signalNumber, error.message());
+    }
+    else
+    {
+        TC_LOG_ERROR("server.authserver", "Received signal: {}", signalNumber);
+    }
     if (!error)
         if (std::shared_ptr<Trinity::Asio::IoContext> ioContext = ioContextRef.lock())
             ioContext->stop();

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -67,6 +67,7 @@
 #include <boost/program_options.hpp>
 #include <csignal>
 #include <iostream>
+#include <exception>
 
 using namespace boost::program_options;
 namespace fs = boost::filesystem;
@@ -295,7 +296,7 @@ extern int main(int argc, char** argv)
     if (!StartDB())
         return 1;
 
-    std::shared_ptr<void> dbHandle(nullptr, [](void*) { StopDB(); });
+    //std::shared_ptr<void> dbHandle(nullptr, [](void*) { StopDB(); });
 
     if (vm.count("update-databases-only"))
         return 0;
@@ -446,9 +447,7 @@ extern int main(int argc, char** argv)
     // 2 - restart command used, this code can be used by restarter for restart Trinityd
 
     // tracy hackfix
-    WorldDatabase.~DatabaseWorkerPool();
-    CharacterDatabase.~DatabaseWorkerPool();
-    LoginDatabase.~DatabaseWorkerPool();
+    StopDB();
     std::exit(World::GetExitCode());
 
     return World::GetExitCode();

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -566,6 +566,15 @@ void WorldUpdateLoop()
 
 void SignalHandler(boost::system::error_code const& error, int /*signalNumber*/)
 {
+    if (error.failed())
+    {
+        TC_LOG_ERROR("server.worldserver", "Received signal: {} and error: {}", signalNumber, error.message());
+    }
+    else
+    {
+        TC_LOG_ERROR("server.worldserver", "Received signal: {}", signalNumber);
+    }
+
     if (!error)
         World::StopNow(SHUTDOWN_EXIT_CODE);
 }

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -564,7 +564,7 @@ void WorldUpdateLoop()
     WorldDatabase.WarnAboutSyncQueries(false);
 }
 
-void SignalHandler(boost::system::error_code const& error, int /*signalNumber*/)
+void SignalHandler(boost::system::error_code const& error, int signalNumber)
 {
     if (error.failed())
     {

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -445,6 +445,12 @@ extern int main(int argc, char** argv)
     // 1 - shutdown at error
     // 2 - restart command used, this code can be used by restarter for restart Trinityd
 
+    // tracy hackfix
+    WorldDatabase.~DatabaseWorkerPool();
+    CharacterDatabase.~DatabaseWorkerPool();
+    LoginDatabase.~DatabaseWorkerPool();
+    std::exit(World::GetExitCode());
+
     return World::GetExitCode();
 }
 


### PR DESCRIPTION
workaround for tracy freezing the game thread on exit. likely cause is https://github.com/wolfpld/tracy/issues/589 which is unresolved on the tracy repo for now. this only resolves the issue of tracy hanging on graceful exit, it does not resolve the issue of tracy hanging on crash, but this can be handled by tswow.